### PR TITLE
Repair support of gnuradio master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(VERSION_API    0)
 set(VERSION_ABI 0)
 set(VERSION_PATCH git)
 
+set(PYTHON3_MIN_VERSION "3.6.5")
 cmake_policy(SET CMP0011 NEW)
 
 # Enable generation of compile_commands.json for code completion engines
@@ -86,14 +87,7 @@ ENDIF()
 ########################################################################
 # Install directories
 ########################################################################
-# find_package(Gnuradio "3.9" REQUIRED runtime fft)
-find_package(Gnuradio "3.8" COMPONENTS runtime fft)
-if(NOT Gnuradio_FOUND)
-    find_package(Gnuradio "3.9" COMPONENTS runtime fft)
-	if(NOT Gnuradio_FOUND)
-	    message(FATAL_ERROR "Unable to find GNURadio 3.8 or 3.9")
-	ENDIF(NOT Gnuradio_FOUND)
-ENDIF(NOT Gnuradio_FOUND)
+find_package(Gnuradio "3.9" REQUIRED runtime fft)
 include(GrVersion)
 
 include(GrPlatform) #define LIB_SUFFIX
@@ -133,9 +127,7 @@ endif(APPLE)
 # Find gnuradio build dependencies
 ########################################################################
 find_package(Doxygen)
-#find_package(PythonLibs 3)
-#find_package(Volk)
-#find_package(SWIG)
+find_package(PythonInterp ${PYTHON_MIN_VERSION} COMPONENTS Interpreter Development NumPy)
 
 
 ########################################################################
@@ -157,30 +149,6 @@ else(DOXYGEN_FOUND)
     option(ENABLE_DOXYGEN "Build docs using Doxygen" OFF)
 endif(DOXYGEN_FOUND)
 
-########################################################################
-# Setup the include and linker paths
-########################################################################
-#include_directories(
-#    ${CMAKE_SOURCE_DIR}/lib
-#    ${CMAKE_SOURCE_DIR}/include
-#    ${CMAKE_BINARY_DIR}/lib
-#    ${CMAKE_BINARY_DIR}/include
-#    ${Boost_INCLUDE_DIRS}
-#    ${CPPUNIT_INCLUDE_DIRS}
-#    ${GNURADIO_ALL_INCLUDE_DIRS}
-#    ${VOLK_INCLUDE_DIRS}
-#)
-
-#link_directories(
-#    ${Boost_LIBRARY_DIRS}
-#    ${CPPUNIT_LIBRARY_DIRS}
-#    ${GNURADIO_RUNTIME_LIBRARY_DIRS}
-#    ${VOLK_LIBRARY_DIRS}
-#)
-
-# Set component parameters
-#set(GR_BOKEHGUI_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include CACHE INTERNAL "" FORCE)
-#set(GR_BOKEHGUI_SWIG_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/swig CACHE INTERNAL "" FORCE)
 
 ########################################################################
 # Create uninstall target
@@ -209,9 +177,6 @@ add_subdirectory(grc)
 ########################################################################
 # Install cmake search helper for this library
 ########################################################################
-#if(NOT CMAKE_MODULES_DIR)
-#  set(CMAKE_MODULES_DIR lib${LIB_SUFFIX}/cmake)
-#endif(NOT CMAKE_MODULES_DIR)
 
 install(FILES cmake/Modules/bokehguiConfig.cmake
     DESTINATION ${CMAKE_MODULES_DIR}/bokehgui

--- a/include/bokehgui/freq_sink_c_proc.h
+++ b/include/bokehgui/freq_sink_c_proc.h
@@ -55,7 +55,7 @@ namespace gr {
     class BOKEHGUI_API freq_sink_c_proc : virtual public base_sink<gr_complex>
     {
      public:
-      typedef boost::shared_ptr<freq_sink_c_proc> sptr;
+      typedef std::shared_ptr<freq_sink_c_proc> sptr;
 
        /*!
         * \brief Build a complex frequency sink
@@ -116,4 +116,3 @@ namespace gr {
 } // namespace gr
 
 #endif /* INCLUDED_BOKEHGUI_FREQ_SINK_C_PROC_H */
-

--- a/include/bokehgui/freq_sink_f_proc.h
+++ b/include/bokehgui/freq_sink_f_proc.h
@@ -55,7 +55,7 @@ namespace gr {
     class BOKEHGUI_API freq_sink_f_proc : virtual public base_sink<float>
     {
      public:
-      typedef boost::shared_ptr<freq_sink_f_proc> sptr;
+      typedef std::shared_ptr<freq_sink_f_proc> sptr;
 
       /*!
        * \brief Build a floating frequency sink
@@ -120,4 +120,3 @@ namespace gr {
 } // namespace gr
 
 #endif /* INCLUDED_BOKEHGUI_FREQ_SINK_F_PROC_H */
-

--- a/include/bokehgui/time_sink_c_proc.h
+++ b/include/bokehgui/time_sink_c_proc.h
@@ -58,7 +58,7 @@ namespace gr {
     class BOKEHGUI_API time_sink_c_proc : virtual public base_sink<gr_complex>
     {
      public:
-      typedef boost::shared_ptr<time_sink_c_proc> sptr;
+      typedef std::shared_ptr<time_sink_c_proc> sptr;
 
       /*!
        * \brief Build time sink for complex values
@@ -136,4 +136,3 @@ namespace gr {
 } // namespace gr
 
 #endif /* INCLUDED_BOKEHGUI_TIME_SINK_C_PROC_H */
-

--- a/include/bokehgui/time_sink_f_proc.h
+++ b/include/bokehgui/time_sink_f_proc.h
@@ -52,7 +52,7 @@ namespace gr {
     class BOKEHGUI_API time_sink_f_proc : virtual public base_sink<float>
     {
     public:
-      typedef boost::shared_ptr <time_sink_f_proc> sptr;
+      typedef std::shared_ptr <time_sink_f_proc> sptr;
 
       /*!
        * \brief Build floating point time sink

--- a/include/bokehgui/vec_sink_c_proc.h
+++ b/include/bokehgui/vec_sink_c_proc.h
@@ -54,7 +54,7 @@ namespace gr {
     class BOKEHGUI_API vec_sink_c_proc : virtual public base_sink<gr_complex>
     {
      public:
-      typedef boost::shared_ptr<vec_sink_c_proc> sptr;
+      typedef std::shared_ptr<vec_sink_c_proc> sptr;
 
       /*!
        * \brief Build a floating point vector sink

--- a/include/bokehgui/vec_sink_f_proc.h
+++ b/include/bokehgui/vec_sink_f_proc.h
@@ -54,7 +54,7 @@ namespace gr {
     class BOKEHGUI_API vec_sink_f_proc : virtual public base_sink<float>
     {
      public:
-      typedef boost::shared_ptr<vec_sink_f_proc> sptr;
+      typedef std::shared_ptr<vec_sink_f_proc> sptr;
 
       /*!
        * \brief Build a floating point vector sink

--- a/include/bokehgui/waterfall_sink_c_proc.h
+++ b/include/bokehgui/waterfall_sink_c_proc.h
@@ -31,7 +31,7 @@ namespace gr {
     class BOKEHGUI_API waterfall_sink_c_proc : virtual public base_sink<gr_complex>
     {
     public:
-      typedef boost::shared_ptr <waterfall_sink_c_proc> sptr;
+      typedef std::shared_ptr <waterfall_sink_c_proc> sptr;
       static sptr make(int size,
                        int wintype,
                        double fc,

--- a/include/bokehgui/waterfall_sink_f_proc.h
+++ b/include/bokehgui/waterfall_sink_f_proc.h
@@ -31,7 +31,7 @@ namespace gr {
     class BOKEHGUI_API waterfall_sink_f_proc : virtual public base_sink<float>
     {
     public:
-      typedef boost::shared_ptr <waterfall_sink_f_proc> sptr;
+      typedef std::shared_ptr <waterfall_sink_f_proc> sptr;
       static sptr make(int size,
                        int wintype,
                        double fc, double bw,


### PR DESCRIPTION
It's mostly a change from using boost smart pointers to standard ones.
And dropping python 2 support.