### PR TITLE
Bokeh 2 support with updated event loop

### DIFF
--- a/examples/test_bokehgui.grc
+++ b/examples/test_bokehgui.grc
@@ -94,6 +94,68 @@ blocks:
     coordinate: [728, 172.0]
     rotation: 0
     state: enabled
+- name: ntype_cmplx
+  id: variable_bokehgui_checkbox
+  parameters:
+    comment: ''
+    'false': '200'
+    inline: 'True'
+    label: Noise Type
+    'true': '201'
+    type: int
+    value: '201'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [58, 431]
+    rotation: 0
+    state: enabled
+- name: ntype_float
+  id: variable_bokehgui_radiobutton
+  parameters:
+    comment: ''
+    inline: 'False'
+    label0: Uniform
+    label1: Gaussian
+    label2: Laplacian
+    label3: Impulse
+    label4: ''
+    labels: '[]'
+    num_opts: '4'
+    option0: '200'
+    option1: '201'
+    option2: '201'
+    option3: '203'
+    option4: '4'
+    options: '[0, 1, 2]'
+    type: int
+    value: '201'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [537, 468]
+    rotation: 0
+    state: enabled
+- name: offset
+  id: variable_bokehgui_range_slider
+  parameters:
+    comment: ''
+    end: '2'
+    label: Offsets
+    start: '-2'
+    step: '0.1'
+    throttle: '1'
+    type: real_vector
+    value: (-1, 0)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [244, 419]
+    rotation: 0
+    state: true
 - name: samp_rate
   id: variable
   parameters:
@@ -133,7 +195,7 @@ blocks:
     comment: ''
     maxoutbuf: '0'
     minoutbuf: '0'
-    noise_type: analog.GR_GAUSSIAN
+    noise_type: ntype_cmplx
     seed: '0'
     type: complex
   states:
@@ -152,7 +214,7 @@ blocks:
     comment: ''
     maxoutbuf: '0'
     minoutbuf: '0'
-    noise_type: analog.GR_GAUSSIAN
+    noise_type: ntype_float
     seed: '0'
     type: float
   states:
@@ -172,7 +234,7 @@ blocks:
     freq: frequency
     maxoutbuf: '0'
     minoutbuf: '0'
-    offset: '0'
+    offset: offset[0]
     phase: '0'
     samp_rate: samp_rate
     type: complex
@@ -194,7 +256,7 @@ blocks:
     freq: frequency
     maxoutbuf: '0'
     minoutbuf: '0'
-    offset: '0'
+    offset: offset[1]
     phase: '0'
     samp_rate: samp_rate
     type: float

--- a/examples/test_bokehgui.grc
+++ b/examples/test_bokehgui.grc
@@ -14,9 +14,9 @@ options:
     id: test_bokehgui
     max_nouts: '0'
     output_language: python
-    placement: (0,0,1,1)
+    placement: (0,0,5,1)
     qt_qss_theme: ''
-    realtime_scheduling: ''
+    realtime_scheduling: '1'
     run: 'True'
     run_command: '{python} -u {filename}'
     run_options: prompt
@@ -27,7 +27,7 @@ options:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [536, 364.0]
+    coordinate: [8, 3]
     rotation: 0
     state: enabled
 
@@ -43,7 +43,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [248, 340.0]
+    coordinate: [197, 6]
     rotation: 0
     state: enabled
 - name: frequency
@@ -52,12 +52,12 @@ blocks:
     comment: ''
     label: Frequency
     type: real
-    value: '10000'
+    value: '1000'
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [728, 324.0]
+    coordinate: [367, 6]
     rotation: 0
     state: enabled
 - name: funct_probe
@@ -73,7 +73,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [728, 32]
+    coordinate: [835, 13]
     rotation: 0
     state: disabled
 - name: noise_amp
@@ -91,7 +91,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [728, 172.0]
+    coordinate: [198, 87]
     rotation: 0
     state: enabled
 - name: ntype_cmplx
@@ -108,7 +108,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [58, 431]
+    coordinate: [674, 7]
     rotation: 0
     state: enabled
 - name: ntype_float
@@ -135,7 +135,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [537, 468]
+    coordinate: [1009, 10]
     rotation: 0
     state: enabled
 - name: offset
@@ -153,19 +153,19 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [244, 419]
+    coordinate: [496, 90]
     rotation: 0
     state: true
 - name: samp_rate
   id: variable
   parameters:
     comment: ''
-    value: '32000'
+    value: '5000'
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [424, 356.0]
+    coordinate: [8, 100]
     rotation: 0
     state: enabled
 - name: signal_amp
@@ -183,7 +183,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [904, 172.0]
+    coordinate: [340, 89]
     rotation: 0
     state: enabled
 - name: analog_noise_source_x_0
@@ -202,7 +202,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [16, 132.0]
+    coordinate: [68, 423]
     rotation: 0
     state: enabled
 - name: analog_noise_source_x_1
@@ -221,7 +221,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [16, 332.0]
+    coordinate: [58, 785]
     rotation: 0
     state: enabled
 - name: analog_sig_source_x_0
@@ -243,7 +243,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [16, 8]
+    coordinate: [68, 299]
     rotation: 0
     state: enabled
 - name: analog_sig_source_x_1
@@ -265,7 +265,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [16, 208]
+    coordinate: [58, 661]
     rotation: 0
     state: enabled
 - name: blocks_add_xx_0
@@ -283,7 +283,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [248, 48.0]
+    coordinate: [300, 339]
     rotation: 0
     state: enabled
 - name: blocks_add_xx_1
@@ -301,9 +301,27 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [248, 248.0]
+    coordinate: [290, 701]
     rotation: 0
     state: enabled
+- name: blocks_stream_to_vector_0
+  id: blocks_stream_to_vector
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_items: '64'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [906, 343]
+    rotation: 0
+    state: true
 - name: blocks_throttle_0
   id: blocks_throttle
   parameters:
@@ -320,7 +338,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [344, 60.0]
+    coordinate: [396, 351]
     rotation: 0
     state: enabled
 - name: blocks_throttle_1
@@ -339,7 +357,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [344, 260.0]
+    coordinate: [386, 713]
     rotation: 0
     state: enabled
 - name: bokehgui_frequency_sink_x_0
@@ -401,7 +419,7 @@ blocks:
     minoutbuf: '0'
     name: Complex Frequency Sink
     nconnections: '1'
-    placement: (1,0,2,1)
+    placement: (0,3,2,2)
     style1: '"solid"'
     style10: '"solid"'
     style2: '"solid"'
@@ -439,9 +457,9 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [536, -4.0]
+    coordinate: [602, 262]
     rotation: 0
-    state: disabled
+    state: enabled
 - name: bokehgui_frequency_sink_x_1
   id: bokehgui_frequency_sink_x
   parameters:
@@ -496,12 +514,12 @@ blocks:
     marker7: None
     marker8: None
     marker9: None
-    maxhold: 'True'
+    maxhold: 'False'
     maxoutbuf: '0'
     minoutbuf: '0'
     name: Float Frequency Sink
     nconnections: '1'
-    placement: (3,0,2,1)
+    placement: (2,3,2,2)
     style1: '"solid"'
     style10: '"solid"'
     style2: '"solid"'
@@ -539,9 +557,106 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [536, 188.0]
+    coordinate: [608, 636]
     rotation: 0
-    state: disabled
+    state: enabled
+- name: bokehgui_time_const_x_0
+  id: bokehgui_time_const_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    axislabels: 'True'
+    color1: '"blue"'
+    color10: '"blue"'
+    color2: '"red"'
+    color3: '"green"'
+    color4: '"black"'
+    color5: '"cyan"'
+    color6: '"magenta"'
+    color7: '"yellow"'
+    color8: '"blue"'
+    color9: '"blue"'
+    comment: ''
+    entags: 'True'
+    grid: 'False'
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    marker1: '''o'''
+    marker10: '''o'''
+    marker2: '''o'''
+    marker3: '''o'''
+    marker4: '''o'''
+    marker5: '''o'''
+    marker6: '''o'''
+    marker7: '''o'''
+    marker8: '''o'''
+    marker9: '''o'''
+    name: '""'
+    nconnections: '1'
+    placement: (5,3,2,2)
+    size: '1024'
+    srate: samp_rate
+    style10: ''
+    style2: ''
+    style3: ''
+    style4: ''
+    style5: ''
+    style6: ''
+    style7: ''
+    style8: ''
+    style9: ''
+    tr_chan: '0'
+    tr_delay: '0'
+    tr_level: '0.0'
+    tr_mode: bokehgui.TRIG_MODE_FREE
+    tr_slope: bokehgui.TRIG_SLOPE_POS
+    tr_tag: '""'
+    type: complex
+    update_time: '100'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    xlabel: I Channel
+    xmax: '100'
+    xmin: '-100'
+    xunit: '""'
+    ylabel: Q Channel
+    ymax: '100'
+    ymin: '-100'
+    yunit: '""'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [601, 512]
+    rotation: 0
+    state: true
 - name: bokehgui_time_sink_x_0
   id: bokehgui_time_sink_x
   parameters:
@@ -637,7 +752,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [536, 108.0]
+    coordinate: [601, 435]
     rotation: 0
     state: enabled
 - name: bokehgui_time_sink_x_1
@@ -735,9 +850,302 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [536, 284.0]
+    coordinate: [608, 808]
     rotation: 0
     state: enabled
+- name: bokehgui_vector_sink_x_0
+  id: bokehgui_vector_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    average: '1.0'
+    axislabels: 'True'
+    color1: '"blue"'
+    color10: '"dark blue"'
+    color2: '"red"'
+    color3: '"green"'
+    color4: '"black"'
+    color5: '"cyan"'
+    color6: '"magenta"'
+    color7: '"yellow"'
+    color8: '"dark red"'
+    color9: '"dark green"'
+    comment: ''
+    grid: 'False'
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    marker1: None
+    marker10: None
+    marker2: None
+    marker3: None
+    marker4: None
+    marker5: None
+    marker6: None
+    marker7: None
+    marker8: None
+    marker9: None
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    nconnections: '1'
+    placement: (0,7,2,2)
+    style1: '"solid"'
+    style10: '"solid"'
+    style2: '"solid"'
+    style3: '"solid"'
+    style4: '"solid"'
+    style5: '"solid"'
+    style6: '"solid"'
+    style7: '"solid"'
+    style8: '"solid"'
+    style9: '"solid"'
+    type: complex
+    update_time: '100'
+    vec_len: '64'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    x_values: list(range(64))
+    xlabel: Frequency
+    xunit: '""'
+    ylabel: Relative Gain
+    ymax: '10'
+    ymin: '-140'
+    yunit: dB
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1379, 363]
+    rotation: 0
+    state: true
+- name: bokehgui_vector_sink_x_0_0
+  id: bokehgui_vector_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    average: '1.0'
+    axislabels: 'True'
+    color1: '"blue"'
+    color10: '"dark blue"'
+    color2: '"red"'
+    color3: '"green"'
+    color4: '"black"'
+    color5: '"cyan"'
+    color6: '"magenta"'
+    color7: '"yellow"'
+    color8: '"dark red"'
+    color9: '"dark green"'
+    comment: ''
+    grid: 'False'
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    marker1: None
+    marker10: None
+    marker2: None
+    marker3: None
+    marker4: None
+    marker5: None
+    marker6: None
+    marker7: None
+    marker8: None
+    marker9: None
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    nconnections: '1'
+    placement: (2,7,2,2)
+    style1: '"solid"'
+    style10: '"solid"'
+    style2: '"solid"'
+    style3: '"solid"'
+    style4: '"solid"'
+    style5: '"solid"'
+    style6: '"solid"'
+    style7: '"solid"'
+    style8: '"solid"'
+    style9: '"solid"'
+    type: float
+    update_time: '100'
+    vec_len: '64'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    x_values: list(range(64))
+    xlabel: Frequency
+    xunit: '""'
+    ylabel: Relative Gain
+    ymax: '10'
+    ymin: '-140'
+    yunit: dB
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1374, 684]
+    rotation: 0
+    state: true
+- name: bokehgui_waterfall_sink_x_0
+  id: bokehgui_waterfall_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    bw: samp_rate
+    color: Inferno
+    comment: ''
+    fc: '0'
+    fftsize: '1024'
+    grid: 'False'
+    int_max: '10'
+    int_min: '-140'
+    label: ''
+    legend: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    placement: (0,5,2,2)
+    type: complex
+    update_time: '100'
+    wintype: firdes.WIN_BLACKMAN_hARRIS
+    xlabel: Frequency
+    xunit: Hz
+    ylabel: Time
+    yunit: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [602, 356]
+    rotation: 0
+    state: true
+- name: bokehgui_waterfall_sink_x_0_0
+  id: bokehgui_waterfall_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    bw: samp_rate
+    color: Inferno
+    comment: ''
+    fc: '0'
+    fftsize: '1024'
+    grid: 'False'
+    int_max: '10'
+    int_min: '-140'
+    label: ''
+    legend: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    placement: (2,5,2,2)
+    type: float
+    update_time: '100'
+    wintype: firdes.WIN_BLACKMAN_hARRIS
+    xlabel: Frequency
+    xunit: Hz
+    ylabel: Time
+    yunit: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [608, 731]
+    rotation: 0
+    state: true
+- name: fft_vxx_0
+  id: fft_vxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    fft_size: '64'
+    forward: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    nthreads: '1'
+    shift: 'True'
+    type: complex
+    window: window.blackmanharris(64)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1070, 306]
+    rotation: 0
+    state: true
+- name: logpwrfft_x_0
+  id: logpwrfft_x
+  parameters:
+    affinity: ''
+    alias: ''
+    average: 'False'
+    avg_alpha: '1.0'
+    comment: ''
+    fft_size: '64'
+    frame_rate: '30'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    ref_scale: '2'
+    sample_rate: samp_rate
+    type: float
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [942, 675]
+    rotation: 0
+    state: true
 
 connections:
 - [analog_noise_source_x_0, '0', blocks_add_xx_0, '1']
@@ -746,10 +1154,18 @@ connections:
 - [analog_sig_source_x_1, '0', blocks_add_xx_1, '0']
 - [blocks_add_xx_0, '0', blocks_throttle_0, '0']
 - [blocks_add_xx_1, '0', blocks_throttle_1, '0']
+- [blocks_stream_to_vector_0, '0', fft_vxx_0, '0']
+- [blocks_throttle_0, '0', blocks_stream_to_vector_0, '0']
 - [blocks_throttle_0, '0', bokehgui_frequency_sink_x_0, '0']
+- [blocks_throttle_0, '0', bokehgui_time_const_x_0, '0']
 - [blocks_throttle_0, '0', bokehgui_time_sink_x_0, '0']
+- [blocks_throttle_0, '0', bokehgui_waterfall_sink_x_0, '0']
 - [blocks_throttle_1, '0', bokehgui_frequency_sink_x_1, '0']
 - [blocks_throttle_1, '0', bokehgui_time_sink_x_1, '0']
+- [blocks_throttle_1, '0', bokehgui_waterfall_sink_x_0_0, '0']
+- [blocks_throttle_1, '0', logpwrfft_x_0, '0']
+- [fft_vxx_0, '0', bokehgui_vector_sink_x_0, '0']
+- [logpwrfft_x_0, '0', bokehgui_vector_sink_x_0_0, '0']
 
 metadata:
   file_format: 1

--- a/grc/bokehgui_const_sink_x.block.yml
+++ b/grc/bokehgui_const_sink_x.block.yml
@@ -436,13 +436,6 @@ templates:
       % endif
       )
 
-      self.${id}_plot = bokehgui.${type.plot}(self.doc, self.plot_lst, self.${id}, is_message =\
-      % if type.t == 'message' :
-       True\
-      % else :
-       False\
-      % endif
-      )
       labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
                 ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]
       legend_list = []
@@ -461,8 +454,13 @@ templates:
         else:
             legend_list.append(labels[i])
 
-      self.${id}_plot.initialize(update_time = ${update_time},
-                                  legend_list = legend_list)
+      self.${id}_plot = bokehgui.${type.plot}(self.plot_lst, self.${id}, update_time = ${update_time}, legend_list = legend_list, is_message =\
+      % if type.t == 'message' :
+       True\
+      % else :
+       False\
+      % endif
+      )
 
       self.${id}_plot.set_y_axis([${ymin}, ${ymax}])
       self.${id}_plot.set_x_axis([${xmin}, ${xmax}])
@@ -481,7 +479,7 @@ templates:
       self.${id}_plot.set_trigger_mode(${tr_mode}, ${tr_slope}, ${tr_level}, ${tr_delay}, ${tr_chan}, ${tr_tag})
       self.${id}_plot.enable_grid(${grid})
       self.${id}_plot.enable_axis_labels(${axislabels})
-      self.${id}_plot.disable_legend(not ${legend})
+      self.${id}_plot.enable_legend(${legend})
       self.${id}_plot.set_layout(*(${placement}))
       colors = [${color1}, ${color2}, ${color3}, ${color4}, ${color5},
                 ${color6}, ${color7}, ${color8}, ${color9}, ${color10}]

--- a/grc/bokehgui_freq_sink_x.block.yml
+++ b/grc/bokehgui_freq_sink_x.block.yml
@@ -453,13 +453,7 @@ templates:
                              ${nconnections}\
                              % endif
                             )
-        self.${id}_plot = bokehgui.${type.plot}(self.doc, self.plot_lst, self.${id}, is_message =\
-        % if type.t == 'message':
-           True\
-        % else:
-        False\
-        % endif
-        )
+
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
                   ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]
         legend_list = []
@@ -476,8 +470,13 @@ templates:
             else:
                 legend_list.append(labels[i])
 
-        self.${id}_plot.initialize(update_time = ${update_time},\
-                                   legend_list = legend_list)
+        self.${id}_plot = bokehgui.${type.plot}(self.plot_lst, self.${id}, update_time = ${update_time}, legend_list = legend_list, is_message =\
+        % if type.t == 'message':
+           True\
+        % else:
+        False\
+        % endif
+        )
 
         self.${id}_plot.set_y_axis([${ymin}, ${ymax}])
         % if (yunit == ''):
@@ -495,7 +494,7 @@ templates:
 
         self.${id}_plot.enable_grid(${grid})
         self.${id}_plot.enable_axis_labels(${axislabels})
-        self.${id}_plot.disable_legend(not ${legend})
+        self.${id}_plot.enable_legend(${legend})
         % if (type == 'float' or type == 'msg_float'):
         self.${id}_plot.set_plot_pos_half(${freqhalf})
         % endif

--- a/grc/bokehgui_time_sink_x.block.yml
+++ b/grc/bokehgui_time_sink_x.block.yml
@@ -558,13 +558,6 @@ templates:
       % endif
       )
 
-      self.${id}_plot = bokehgui.${type.plot}(self.doc, self.plot_lst, self.${id}, is_message = \
-      % if type.t == 'message':
-        True\
-      % else:
-        False\
-      % endif
-      )
 
       labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
                 ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]
@@ -597,7 +590,14 @@ templates:
         else:
           legend_list.append(labels[i])
       % endif
-      self.${id}_plot.initialize(log_x = ${xlog}, log_y = ${ylog}, update_time = ${update_time}, legend_list = legend_list)
+
+      self.${id}_plot = bokehgui.${type.plot}(self.plot_lst, self.${id}, log_x = ${xlog}, log_y = ${ylog}, update_time = ${update_time}, legend_list = legend_list, is_message = \
+      % if type.t == 'message':
+        True\
+      % else:
+        False\
+      % endif
+      )
 
       self.${id}_plot.set_y_axis([${ymin}, ${ymax}])
       % if (yunit == ""):
@@ -615,7 +615,7 @@ templates:
       self.${id}_plot.set_trigger_mode(${tr_mode}, ${tr_slope}, ${tr_level}, ${tr_delay}, ${tr_chan}, ${tr_tag})
       self.${id}_plot.enable_grid(${grid})
       self.${id}_plot.enable_axis_labels(${axislabels})
-      self.${id}_plot.disable_legend(not ${legend})
+      self.${id}_plot.enable_legend(${legend})
       self.${id}_plot.set_layout(*(${placement}))
 
       colors = [${color1}, ${color2}, ${color3}, ${color4}, ${color5},

--- a/grc/bokehgui_vec_sink_x.block.yml
+++ b/grc/bokehgui_vec_sink_x.block.yml
@@ -506,13 +506,7 @@ templates:
                              ${nconnections}\
                              % endif
                             )
-        self.${id}_plot = bokehgui.${type.plot}(self.doc, self.plot_lst, self.${id}, is_message =\
-        % if type.t == 'message':
-           True\
-        % else:
-        False\
-        % endif
-        )
+
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
                   ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]
         legend_list = []
@@ -545,8 +539,14 @@ templates:
           else:
             legend_list.append(labels[i])
         % endif
-        self.${id}_plot.initialize(update_time = ${update_time},\
-                                   legend_list = legend_list)
+
+        self.${id}_plot = bokehgui.${type.plot}(self.plot_lst, self.${id}, update_time = ${update_time}, legend_list = legend_list, is_message =\
+        % if type.t == 'message':
+           True\
+        % else:
+        False\
+        % endif
+        )
 
         self.${id}_plot.set_y_axis([${ymin}, ${ymax}])
         % if (yunit == ''):
@@ -563,7 +563,7 @@ templates:
         self.${id}_plot.set_x_values(${x_values})
         self.${id}_plot.enable_grid(${grid})
         self.${id}_plot.enable_axis_labels(${axislabels})
-        self.${id}_plot.disable_legend(not ${legend})
+        self.${id}_plot.enable_legend(${legend})
         self.${id}_plot.set_layout(*(${placement}))
         % if maxhold == 'True':
         self.${id}_plot.enable_max_hold()

--- a/grc/bokehgui_waterfall_sink_x.block.yml
+++ b/grc/bokehgui_waterfall_sink_x.block.yml
@@ -128,24 +128,21 @@ templates:
     make: |+
       bokehgui.${type.fcn}(${fftsize}, ${wintype}, ${fc},${bw}, ${name})
 
-      self.${id}_plot = bokehgui.${type.plot}(self.doc, self.plot_lst, self.${id}, is_message = \
-        % if type.t == 'message':
-         True\
-        % else:
-         False\
-        % endif
-        )
-
       legend_list = []
       for i in  range(1):
         if len(${label}) == 0:
           legend_list.append("Data {0}".format(i))
         else:
           legend_list.append(${label})
-
-      self.${id}_plot.initialize(update_time = ${update_time},
+      self.${id}_plot = bokehgui.${type.plot}(self.plot_lst, self.${id}, update_time = ${update_time},
                     legend_list = legend_list, palette = '${color}',
-                    values_range = [${int_min}, ${int_max}])
+                    values_range = [${int_min}, ${int_max}], is_message = \
+        % if type.t == 'message':
+         True\
+        % else:
+         False\
+        % endif
+        )
 
       % if (yunit == ''):
       self.${id}_plot.set_y_label(${ylabel})
@@ -158,7 +155,7 @@ templates:
       self.${id}_plot.set_x_label(${xlabel} + '(' +${xunit}+')')
       % endif
       self.${id}_plot.enable_grid(${grid})
-      self.${id}_plot.disable_legend(not ${legend})
+      self.${id}_plot.enable_legend(${legend})
       self.${id}_plot.set_layout(*(${placement}))
     callbacks:
     - set_frequency_range(${fc}, ${bw})

--- a/python/bokeh_layout.py
+++ b/python/bokeh_layout.py
@@ -219,8 +219,8 @@ class Layout:
                         "arrangements of plots")
 
 
-def create_layout(lst, sizing_mode = "fixed"):
+def create_layout(lst, sizing_mode = "fixed", window_size=(1000,1000)):
     # lst -> [obj] having obj.layout
     layout = Layout(lst)
-    return layout.evaluate(sizing_mode = sizing_mode, height = 700.0,
-                           width = 1210.0)
+    return layout.evaluate(sizing_mode = sizing_mode, height = window_size[0],
+                           width = window_size[1])

--- a/python/bokeh_plot_config.py
+++ b/python/bokeh_plot_config.py
@@ -22,6 +22,25 @@ class bokeh_plot_config(object):
     def __init__(self):
         self.plot = None
         self.stream = None
+        self.title_text = None
+        self.y_range = None
+        self.x_range = None
+        self.y_label = None
+        self.x_label = None
+        self.x_grid = True
+        self.y_grid = True
+        self.en_axis_labels = True
+        self.en_legend = True
+        self.colors = ["blue", "red", "green", "black", "cyan",
+                  "magenta", "yellow", "blue", "blue", "blue"]
+        self.widths = [1, 1, 1, 1, 1,
+                  1, 1, 1, 1, 1]
+        self.styles = ["solid", "solid", "solid", "solid", "solid",
+                  "solid", "solid", "solid", "solid", "solid"]
+        self.markers = [None, None, None, None, None,
+                  None, None, None, None, None]
+        self.alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+                  1.0, 1.0, 1.0, 1.0, 1.0]
 
     def get_figure(self):
         return self.plot
@@ -37,26 +56,36 @@ class bokeh_plot_config(object):
         self.plot.add_tools(hover, crosshair)
 
     def set_title(self, name):
-        self.plot.title.text = name
+        self.title_text = name
+        if self.plot is not None:
+            plot.title.text = self.title_text
 
     def get_title(self):
-        return self.plot.title.text
+        return self.title_text
 
     def set_y_axis(self, lst):
-        from bokeh.models.ranges import Range1d
         assert (lst[0] < lst[1])
-        self.plot.y_range = Range1d(lst[0], lst[1])
+        self.y_range = lst
+        if self.plot is not None:
+            from bokeh.models.ranges import Range1d
+            plot.y_range = Range1d(self.y_range[0], self.y_range[1])
 
     def set_x_axis(self, lst):
-        from bokeh.models.ranges import Range1d
         assert (lst[0] < lst[1])
-        self.plot.x_range = Range1d(lst[0], lst[1])
+        self.x_range = lst
+        if self.plot is not None:
+            from bokeh.models.ranges import Range1d
+            plot.x_range = Range1d(self.x_range[0], self.x_range[1])
 
     def set_x_label(self, xlabel):
-        self.plot.xaxis[0].axis_label = xlabel
+        self.x_label = xlabel
+        if self.plot is not None:
+            plot.xaxis[0].axis_label = self.x_label
 
     def set_y_label(self, ylabel):
-        self.plot.yaxis[0].axis_label = ylabel
+        self.y_label = ylabel
+        if self.plot is not None:
+            plot.yaxis[0].axis_label = self.y_label
 
     def format_line(self, i, color, width, style, marker, alpha):
         self.set_line_color(i, color)
@@ -66,32 +95,38 @@ class bokeh_plot_config(object):
         self.set_line_alpha(i, alpha)
 
     def set_line_color(self, i, color):
-        self.lines[i].glyph.line_color = color
+        self.colors[i] = color
+        if self.plot is not None:
+            self.lines[i].glyph.line_color = color
 
     def get_line_color(self, i):
-        return self.lines[i].glyph.line_color
+        return self.colors[i]
 
     def set_line_width(self, i, width):
-        self.lines[i].glyph.line_width = width
+        self.widths[i] = width
+        if self.plot is not None:
+            self.lines[i].glyph.line_width = self.widths[i]
 
     def get_line_width(self, i):
-        return self.lines[i].glyph.line_width
+        return self.widths[i]
 
     def set_line_style(self, i, style):
-        if style == 'None':
-            self.lines[i].visible = False
-            return
-        self.lines[i].visible = True
-        # solid, dashed, dotted, dotdash, dashdot
-        self.lines[i].glyph.line_dash = style
+        self.styles[i] = style
+        if self.plot is not None:
+            if style == 'None':
+                self.lines[i].visible = False
+                return
+            self.lines[i].visible = True
+            # solid, dashed, dotted, dotdash, dashdot
+            self.lines[i].glyph.line_dash = self.styles[i]
 
     def get_line_style(self, i):
-        if not self.lines[i].visible:
-            return
+        # if not self.lines[i].visible:
+        #     return
         # solid, dashed, dotted, dotdash, dashdot
-        return self.lines[i].glyph.line_dash
+        return self.styles[i]
 
-    def set_line_marker(self, i, marker):
+    def use_line_marker(self, i, marker):
         if marker == 'None':
             self.lines_markers[i] = (None, None)
         if marker == '*':
@@ -146,43 +181,48 @@ class bokeh_plot_config(object):
             self.plot.x(x = 'x', y = 'y' + str(i), source = self.stream,
                     legend = self.legend_list[i], ), 'x')
 
+    def set_line_marker(self, i, marker):
+        self.markers[i] = marker
+        if self.plot is not None:
+            self.use_line_marker(i,self.markers[i])
+
     def get_line_marker(self, i):
-        return self.lines_markers[i][1]
+        return self.markers[i]
 
     def set_line_alpha(self, i, alpha):
-        self.lines[i].glyph.line_alpha = alpha
+        self.alphas[i] = alpha
+        if self.plot is not None:
+            self.lines[i].glyph.line_alpha = self.alphas[i]
 
     def get_line_alpha(self, i):
-        return self.lines[i].glyph.line_alpha
+        return self.alphas[i]
 
     def enable_x_grid(self, en = True):
-        if en:
-            self.plot.xgrid[0].grid_line_alpha = 1
-        else:
-            self.plot.xgrid[0].grid_line_alpha = 0
+        self.x_grid = en
+        if self.plot is not None:
+            self.plot.xgrid.visible = self.x_grid
 
     def enable_y_grid(self, en = True):
-        if en:
-            self.plot.ygrid.grid_line_alpha = 1
-        else:
-            self.plot.ygrid.grid_line_alpha = 0
+        self.y_grid = en
+        if self.plot is not None:
+            self.plot.ygrid.visible = self.y_grid
 
     def enable_grid(self, en = True):
         self.enable_x_grid(en)
         self.enable_y_grid(en)
 
     def enable_axis_labels(self, en = True):
-        if en:
-            self.plot.xaxis[0].axis_label_text_color = '#000000'
-            self.plot.yaxis[0].axis_label_text_color = '#000000'
-        else:
-            self.plot.xaxis[0].axis_label_text_color = '#FFFFFF'
-            self.plot.yaxis[0].axis_label_text_color = '#FFFFFF'
+        self.en_axis_labels = en
+        if self.plot is not None:
+            if self.en_axis_labels:
+                self.plot.xaxis[0].axis_label_text_color = '#000000'
+                self.plot.yaxis[0].axis_label_text_color = '#000000'
+            else:
+                self.plot.xaxis[0].axis_label_text_color = '#FFFFFF'
+                self.plot.yaxis[0].axis_label_text_color = '#FFFFFF'
 
-    def disable_legend(self, en = True):
-        if en:
-            self.plot.legend[0].visible = False
-            self.plot.legend[0].click_policy = "hide"
-        else:
-            self.plot.legend[0].visible = True
+    def enable_legend(self, en = True):
+        self.en_legend = en
+        if self.plot is not None:
+            self.plot.legend[0].visible = self.en_legend
             self.plot.legend[0].click_policy = "hide"

--- a/python/button.py
+++ b/python/button.py
@@ -21,14 +21,20 @@ from bokeh.models import Button, Toggle
 
 class button():
     def __init__(self, widget_lst, label):
-        self.widget_lst = widget_lst
+        self.label = label
         self.button = None
-        self.initialize(label)
+        self.callback = None
+        # self.initialize(default_value, label, inline)
+        widget_lst.append(self)
 
-    def initialize(self, label):
+    def initialize(self, widget_lst):
         # self.button = Button(label = label) # Using a simple button doesn't trigger callbacks for some reason
-        self.button = Toggle(label = label)
-        self.widget_lst.append(self.button)
+        self.button = Toggle(label = self.label)
+        widget_lst.append(self.button)
+        if self.callback is not None:
+            self.button.on_click(self.callback)
 
     def add_callback(self, callback):
-        self.button.on_click(callback)
+        self.callback = callback
+        if self.button is not None:
+            self.button.on_click(self.callback)

--- a/python/checkbox.py
+++ b/python/checkbox.py
@@ -20,14 +20,22 @@ from bokeh.models.widgets import CheckboxGroup
 
 class checkbox():
     def __init__(self, widget_lst, default_value, label, inline = True):
-        self.widget_lst = widget_lst
+        self.label = label
+        self.default_value = default_value
+        self.inline = inline
         self.checkbox = None
-        self.initialize(default_value, label, inline)
+        self.callback = None
+        # self.initialize(default_value, label, inline)
+        widget_lst.append(self)
 
-    def initialize(self, default_value, label, inline):
-        self.checkbox = CheckboxGroup(active = default_value, labels = [label],
-                                      inline = inline)
-        self.widget_lst.append(self.checkbox)
+    def initialize(self, widget_lst):
+        self.checkbox = CheckboxGroup(active = self.default_value, labels = [self.label],
+                                      inline = self.inline)
+        widget_lst.append(self.checkbox)
+        if self.callback is not None:
+            self.checkbox.on_click(self.callback)
 
     def add_callback(self, callback):
-        self.checkbox.on_click(callback)
+        self.callback = callback
+        if self.checkbox is not None:
+            self.checkbox.on_click(self.callback)

--- a/python/const_sink_c.py
+++ b/python/const_sink_c.py
@@ -102,7 +102,7 @@ class const_sink_c(bokeh_plot_config):
             self.lines_markers.append((
                 plot.scatter(x = 'x' + str(i), y = 'y' + str(i),
                                   source = stream,
-                                  legend = self.legend_list[i], ), 'o'))
+                                  legend_label = self.legend_list[i], ), 'o'))
 
             if self.tags_enabled:
                 if not self.is_message:
@@ -268,54 +268,54 @@ class const_sink_c(bokeh_plot_config):
         if marker == '*':
             self.lines_markers[i] = (
             self.plot.asterisk(x = 'x' + str(i), y = 'y' + str(i), source = self.stream,
-                    legend = self.legend_list[i], ), '*')
+                    legend_label = self.legend_list[i], ), '*')
         if marker == 'o':
             self.lines_markers[i] = (
             self.plot.circle(x = 'x' + str(i), y = 'y' + str(i), source = self.stream,
-                    legend = self.legend_list[i], ), 'o')
+                    legend_label = self.legend_list[i], ), 'o')
         if marker == 'o+':
             self.lines_markers[i] = (
             self.plot.circle_cross(x = 'x' + str(i), y = 'y' + str(i),
-                    source = self.stream, legend = self.legend_list[i], ),
+                    source = self.stream, legend_label = self.legend_list[i], ),
             'o+')
         if marker == '+':
             self.lines_markers[i] = (
             self.plot.cross(x = 'x' + str(i), y = 'y' + str(i), source = self.stream,
-                    legend = self.legend_list[i], ), '+')
+                    legend_label = self.legend_list[i], ), '+')
         if marker == 'd':
             self.lines_markers[i] = (
             self.plot.diamond(x = 'x' + str(i), y = 'y' + str(i), source = self.stream,
-                    legend = self.legend_list[i], ), 'd')
+                    legend_label = self.legend_list[i], ), 'd')
         if marker == 'd+':
             self.lines_markers[i] = (
             self.plot.diamond_cross(x = 'x' + str(i), y = 'y' + str(i),
-                    source = self.stream, legend = self.legend_list[i], ),
+                    source = self.stream, legend_label = self.legend_list[i], ),
             'd+')
         if marker == 'v':
             self.lines_markers[i] = (
             self.plot.inverted_triangle(x = 'x' + str(i), y = 'y' + str(i),
-                    source = self.stream, legend = self.legend_list[i], ), 'v')
+                    source = self.stream, legend_label = self.legend_list[i], ), 'v')
         if marker == 's':
             self.lines_markers[i] = (
             self.plot.square(x = 'x' + str(i), y = 'y' + str(i), source = self.stream,
-                    legend = self.legend_list[i], ), 's')
+                    legend_label = self.legend_list[i], ), 's')
         if marker == 's+':
             self.lines_markers[i] = (
             self.plot.square_cross(x = 'x' + str(i), y = 'y' + str(i),
-                    source = self.stream, legend = self.legend_list[i], ),
+                    source = self.stream, legend_label = self.legend_list[i], ),
             's+')
         if marker == 'sx':
             self.lines_markers[i] = (
             self.plot.square_x(x = 'x' + str(i), y = 'y' + str(i), source = self.stream,
-                    legend = self.legend_list[i], ), 'sx')
+                    legend_label = self.legend_list[i], ), 'sx')
         if marker == '^':
             self.lines_markers[i] = (
             self.plot.triangle(x = 'x' + str(i), y = 'y' + str(i), source = self.stream,
-                    legend = self.legend_list[i], ), '^')
+                    legend_label = self.legend_list[i], ), '^')
         if marker == 'x':
             self.lines_markers[i] = (
             self.plot.x(x = 'x' + str(i), y = 'y' + str(i), source = self.stream,
-                    legend = self.legend_list[i], ), 'x')
+                    legend_label = self.legend_list[i], ), 'x')
 
 
     def add_custom_tools(self):

--- a/python/freq_sink_c.py
+++ b/python/freq_sink_c.py
@@ -18,6 +18,7 @@
 
 from bokeh.models import ColumnDataSource, CustomJS
 from bokeh.plotting import figure
+from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
 
 
@@ -28,12 +29,11 @@ class freq_sink_c(bokeh_plot_config):
     freq_sink_c_proc class and streams to the frontend plot.
     """
 
-    def __init__(self, doc, plot_lst, proc, is_message = False):
+    def __init__(self, plot_lst, process, legend_list = utils.default_labels_f,
+                   update_time = 100, is_message = False):
         super(freq_sink_c, self).__init__()
 
-        self.doc = doc
-        self.process = proc
-        self.plot_lst = plot_lst
+        self.process = process
 
         self.size = self.process.get_size()
         self.wintype = self.process.get_wintype()
@@ -52,14 +52,19 @@ class freq_sink_c(bokeh_plot_config):
         self.lines = None
         self.lines_markers = None
         self.legend_list = None
-        self.max_hold = None
+        self.max_hold = False
+        self.max_hold_plot = None
+
+        self.legend_list = legend_list[:]
+        self.update_time = update_time
+
+        plot_lst.append(self)
 
     def set_trigger_mode(self, trigger_mode, level, channel, tag_key):
         self.process.set_trigger_mode(trigger_mode, level, channel, tag_key)
 
-    def initialize(self, legend_list = utils.default_labels_f,
-                   update_time = 100):
-        self.plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
+    def initialize(self, doc, plot_lst):
+        plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
                            active_scroll = 'ywheel_zoom',
                            output_backend="webgl")
         data = dict()
@@ -72,33 +77,86 @@ class freq_sink_c(bokeh_plot_config):
         for i in range(nconn):
             data['y' + str(i)] = []
 
-        self.stream = ColumnDataSource(data)
+        stream = ColumnDataSource(data)
 
         self.lines = []
         self.lines_markers = []
-        self.legend_list = legend_list[:]
         for i in range(self.nconnections):
             self.lines.append(
-                self.plot.line(x = 'x', y = 'y' + str(i), source = self.stream,
-                               line_color = 'blue',
-                               legend = self.legend_list[i]))
+                plot.line(x = 'x', y = 'y' + str(i),
+                         source = stream,
+                         line_color = self.colors[i],
+                         line_width = self.widths[i], line_alpha=self.alphas[i],
+                         legend_label = self.legend_list[i]))
             self.lines_markers.append((None, None))
+            if self.styles[i] == 'None':
+                self.lines[i].visible = False
+            else:
+                self.lines[i].glyph.line_dash = self.styles[i]
 
+        if self.title_text is not None:
+            plot.title.text = self.title_text
+        if self.y_range is not None:
+            plot.y_range = Range1d(self.y_range[0], self.y_range[1])
+        if self.x_range is not None:
+            plot.x_range = Range1d(self.x_range[0], self.x_range[1])
+        if self.y_label is not None:
+            plot.yaxis[0].axis_label = self.y_label
+        if self.x_label is not None:
+            plot.xaxis[0].axis_label = self.x_label
+        plot.xgrid.visible = self.x_grid
+        plot.ygrid.visible = self.y_grid
+        if self.en_axis_labels:
+            plot.xaxis[0].axis_label_text_color = '#000000'
+            plot.yaxis[0].axis_label_text_color = '#000000'
+        else:
+            plot.xaxis[0].axis_label_text_color = '#FFFFFF'
+            plot.yaxis[0].axis_label_text_color = '#FFFFFF'
+        plot.legend[0].visible = self.en_legend
+        plot.legend[0].click_policy = "hide"
+
+        self.plot = plot
+        self.stream = stream
         self.add_custom_tools()
 
         # Add max-hold plot
-        self.max_hold = None
-        self.enable_max_hold(False)
+        max_hold_source = ColumnDataSource(
+                data = dict(x = range(self.size),
+                            y = [float("-inf")] * self.size))
+        self.max_hold_plot = plot.line(x = 'x', y = 'y',
+                                       source = max_hold_source,
+                                       line_color = 'green',
+                                       line_dash = 'dotdash',
+                                       legend_label= 'Max')
+        callback = CustomJS(args = dict(max_hold_source = max_hold_source),
+                            code = """
+                        var no_of_elem = cb_obj.data.x.length;
+                        var data = cb_obj.data;
+                        nconn = Object.getOwnPropertyNames(data).length -1;
+                        var max_data = max_hold_source.data;
+                        max_data.x = cb_obj.data.x;
+
+                        for(n = 0; n < nconn; n++) {
+                               for (i = 0; i < no_of_elem; i++) {
+                                   if(max_data['y'][i] < data['y'+n][i]) {
+                                       max_data['y'][i] = data['y'+n][i]
+                                   }
+                               }
+                        }
+                        max_hold_source.change.emit();
+                        """)
+        stream.js_on_change("streaming", callback)
+        self.max_hold_plot.visible = self.max_hold
         # max-hold plot done
 
-        self.plot_lst.append(self)
+        plot_lst.append(self)
 
-        if self.name:
-            self.set_title(self.name)
+        def callback():
+            self.update(stream)
 
-        self.doc.add_periodic_callback(self.update, update_time)
+        doc.add_periodic_callback(callback, self.update_time)
 
-    def update(self):
+    def update(self, stream):
         # Call to receive from buffers
 
         # First call to check if BW and FC is not changed
@@ -118,7 +176,7 @@ class freq_sink_c(bokeh_plot_config):
                     continue
                 new_data['y' + str(i)] = output_items[i]
             new_data['x'] = self.frequency_range
-            self.stream.stream(new_data, rollover = self.size)
+            stream.stream(new_data, rollover = self.size)
         return
 
     def set_frequency_range(self, fc, bw, set_x_axis = True,
@@ -162,36 +220,6 @@ class freq_sink_c(bokeh_plot_config):
         self.process.fftresize(fftsize)
 
     def enable_max_hold(self, en = True):
-        if self.max_hold is None:
-            max_hold_source = ColumnDataSource(
-                    data = dict(x = range(self.size), y = [-1000] * self.size))
-            self.max_hold = self.plot.line(x = 'x', y = 'y',
-                                           source = max_hold_source,
-                                           line_color = 'green',
-                                           line_dash = 'dotdash',
-                                           line_alpha = 0)
-            callback = CustomJS(
-                    args = dict(max_hold_source = self.max_hold.data_source),
-                    code = """
-                        var no_of_elem = cb_obj.data.x.length;
-                        var data = cb_obj.data;
-                        nconn = Object.getOwnPropertyNames(data).length - 1;
-                        var max_data = max_hold_source.data;
-                        max_data.x = cb_obj.data.x;
-
-                        for(n = 0; n < nconn; n++) {
-                            for (i = 0; i < no_of_elem; i++) {
-                                if(max_data['y'][i] < data['y'+n][i]) {
-                                    max_data['y'][i] = data['y'+n][i];
-                                }
-                            }
-                        }
-                        max_hold_source.change.emit();
-                        """)
-            self.stream.js_on_change("streaming", callback)
-
-        if en:
-            self.max_hold.glyph.line_alpha = 1
-
-        else:
-            self.max_hold.glyph.line_alpha = 0
+        self.max_hold = en
+        if self.max_hold_plot:
+            self.max_hold_plot.visible = self.max_hold

--- a/python/freq_sink_c.py
+++ b/python/freq_sink_c.py
@@ -132,12 +132,12 @@ class freq_sink_c(bokeh_plot_config):
                             code = """
                         var no_of_elem = cb_obj.data.x.length;
                         var data = cb_obj.data;
-                        nconn = Object.getOwnPropertyNames(data).length -1;
+                        const nconn = Object.getOwnPropertyNames(data).length -1;
                         var max_data = max_hold_source.data;
                         max_data.x = cb_obj.data.x;
 
-                        for(n = 0; n < nconn; n++) {
-                               for (i = 0; i < no_of_elem; i++) {
+                        for(let n = 0; n < nconn; n++) {
+                               for (let i = 0; i < no_of_elem; i++) {
                                    if(max_data['y'][i] < data['y'+n][i]) {
                                        max_data['y'][i] = data['y'+n][i]
                                    }

--- a/python/freq_sink_f.py
+++ b/python/freq_sink_f.py
@@ -18,6 +18,7 @@
 
 from bokeh.models import ColumnDataSource, CustomJS
 from bokeh.plotting import figure
+from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
 
 
@@ -28,12 +29,11 @@ class freq_sink_f(bokeh_plot_config):
     freq_sink_f_proc class and streams to the frontend plot.
     """
 
-    def __init__(self, doc, plot_lst, process, is_message = False):
+    def __init__(self, plot_lst, process, legend_list = utils.default_labels_f,
+                   update_time = 100, is_message = False):
         super(freq_sink_f, self).__init__()
 
-        self.doc = doc
         self.process = process
-        self.plot_lst = plot_lst
 
         self.size = self.process.get_size()
         self.wintype = self.process.get_wintype()
@@ -49,17 +49,22 @@ class freq_sink_f(bokeh_plot_config):
                                  notify_process = False)
         self.plot = None
         self.stream = None
-        self.max_hold = None
+        self.max_hold_plot = None
+        self.max_hold = False
         self.legend_list = None
         self.lines_markers = None
         self.lines = None
 
+        self.legend_list = legend_list[:]
+        self.update_time = update_time
+
+        plot_lst.append(self)
+
     def set_trigger_mode(self, trigger_mode, level, channel, tag_key):
         self.process.set_trigger_mode(trigger_mode, level, channel, tag_key)
 
-    def initialize(self, legend_list = utils.default_labels_f,
-                   update_time = 100):
-        self.plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
+    def initialize(self, doc, plot_lst):
+        plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
                            active_scroll = 'ywheel_zoom',
                            output_backend="webgl")
         data = dict()
@@ -71,33 +76,85 @@ class freq_sink_f(bokeh_plot_config):
         for i in range(nconn):
             data['y' + str(i)] = []
 
-        self.stream = ColumnDataSource(data)
+        stream = ColumnDataSource(data)
 
         self.lines = []
         self.lines_markers = []
-        self.legend_list = legend_list[:]
         for i in range(self.nconnections):
-            self.lines.append(self.plot.line(x = 'x', y = 'y' + str(i),
-                                             source = self.stream,
-                                             line_color = 'blue',
-                                             legend = self.legend_list[i]))
+            self.lines.append(plot.line(x = 'x', y = 'y' + str(i),
+                                             source = stream,
+                                             line_color = self.colors[i],
+                                             line_width = self.widths[i], line_alpha=self.alphas[i],
+                                             legend_label = self.legend_list[i]))
             self.lines_markers.append((None, None))
+            if self.styles[i] == 'None':
+                self.lines[i].visible = False
+            else:
+                self.lines[i].glyph.line_dash = self.styles[i]
 
+        if self.title_text is not None:
+            plot.title.text = self.title_text
+        if self.y_range is not None:
+            plot.y_range = Range1d(self.y_range[0], self.y_range[1])
+        if self.x_range is not None:
+            plot.x_range = Range1d(self.x_range[0], self.x_range[1])
+        if self.y_label is not None:
+            plot.yaxis[0].axis_label = self.y_label
+        if self.x_label is not None:
+            plot.xaxis[0].axis_label = self.x_label
+        plot.xgrid.visible = self.x_grid
+        plot.ygrid.visible = self.y_grid
+        if self.en_axis_labels:
+            plot.xaxis[0].axis_label_text_color = '#000000'
+            plot.yaxis[0].axis_label_text_color = '#000000'
+        else:
+            plot.xaxis[0].axis_label_text_color = '#FFFFFF'
+            plot.yaxis[0].axis_label_text_color = '#FFFFFF'
+        plot.legend[0].visible = self.en_legend
+        plot.legend[0].click_policy = "hide"
+
+        self.plot = plot
+        self.stream = stream
         self.add_custom_tools()
 
         # Add max-hold plot
-        self.max_hold = None
-        self.enable_max_hold(False)
+        max_hold_source = ColumnDataSource(
+                data = dict(x = range(self.size),
+                            y = [float("-inf")] * self.size))
+        self.max_hold_plot = plot.line(x = 'x', y = 'y',
+                                       source = max_hold_source,
+                                       line_color = 'green',
+                                       line_dash = 'dotdash',
+                                       legend_label= 'Max')
+        callback = CustomJS(args = dict(max_hold_source = max_hold_source),
+                            code = """
+                        var no_of_elem = cb_obj.data.x.length;
+                        var data = cb_obj.data;
+                        nconn = Object.getOwnPropertyNames(data).length -1;
+                        var max_data = max_hold_source.data;
+                        max_data.x = cb_obj.data.x;
+
+                        for(n = 0; n < nconn; n++) {
+                               for (i = 0; i < no_of_elem; i++) {
+                                   if(max_data['y'][i] < data['y'+n][i]) {
+                                       max_data['y'][i] = data['y'+n][i]
+                                   }
+                               }
+                        }
+                        max_hold_source.change.emit();
+                        """)
+        stream.js_on_change("streaming", callback)
+        self.max_hold_plot.visible = self.max_hold
         # max-hold plot done
 
-        self.plot_lst.append(self)
+        plot_lst.append(self)
 
-        if self.name:
-            self.set_title(self.name)
+        def callback():
+            self.update(stream)
 
-        self.doc.add_periodic_callback(self.update, update_time)
+        doc.add_periodic_callback(callback, self.update_time)
 
-    def update(self):
+    def update(self, stream):
         # Call to receive from buffers
 
         # First call to check if BW and FC is not changed
@@ -117,7 +174,7 @@ class freq_sink_f(bokeh_plot_config):
                     continue
                 new_data['y' + str(i)] = output_items[i]
             new_data['x'] = self.frequency_range
-            self.stream.stream(new_data, rollover = self.size)
+            stream.stream(new_data, rollover = self.size)
         return
 
     def set_frequency_range(self, fc, bw, set_x_axis = True,
@@ -168,35 +225,6 @@ class freq_sink_f(bokeh_plot_config):
             self.set_x_axis([self.fc - self.bw / 2, self.fc + self.bw / 2])
 
     def enable_max_hold(self, en = True):
-        if self.max_hold is None:
-            max_hold_source = ColumnDataSource(
-                    data = dict(x = range(self.size),
-                                y = [float("-inf")] * self.size))
-            self.max_hold = self.plot.line(x = 'x', y = 'y',
-                                           source = max_hold_source,
-                                           line_color = 'green',
-                                           line_dash = 'dotdash',
-                                           line_alpha = 0)
-            callback = CustomJS(args = dict(max_hold_source = max_hold_source),
-                                code = """
-                            var no_of_elem = cb_obj.data.x.length;
-                            var data = cb_obj.data;
-                            nconn = Object.getOwnPropertyNames(data).length -1;
-                            var max_data = max_hold_source.data;
-                            max_data.x = cb_obj.data.x;
-
-                            for(n = 0; n < nconn; n++) {
-                                   for (i = 0; i < no_of_elem; i++) {
-                                       if(max_data['y'][i] < data['y'+n][i]) {
-                                           max_data['y'][i] = data['y'+n][i]
-                                       }
-                                   }
-                            }
-                            max_hold_source.change.emit();
-                            """)
-            self.stream.js_on_change("streaming", callback)
-        if en:
-            self.max_hold.glyph.line_alpha = 1
-
-        else:
-            self.max_hold.glyph.line_alpha = 0
+        self.max_hold = en
+        if self.max_hold_plot:
+            self.max_hold_plot.visible = self.max_hold

--- a/python/freq_sink_f.py
+++ b/python/freq_sink_f.py
@@ -130,12 +130,12 @@ class freq_sink_f(bokeh_plot_config):
                             code = """
                         var no_of_elem = cb_obj.data.x.length;
                         var data = cb_obj.data;
-                        nconn = Object.getOwnPropertyNames(data).length -1;
+                        const nconn = Object.getOwnPropertyNames(data).length -1;
                         var max_data = max_hold_source.data;
                         max_data.x = cb_obj.data.x;
 
-                        for(n = 0; n < nconn; n++) {
-                               for (i = 0; i < no_of_elem; i++) {
+                        for(let n = 0; n < nconn; n++) {
+                               for (let i = 0; i < no_of_elem; i++) {
                                    if(max_data['y'][i] < data['y'+n][i]) {
                                        max_data['y'][i] = data['y'+n][i]
                                    }

--- a/python/label.py
+++ b/python/label.py
@@ -20,14 +20,18 @@ from bokeh.models.widgets import TextInput
 
 class label():
     def __init__(self, widget_lst, default_value, label):
-        self.widget_lst = widget_lst
+        self.label = label
+        self.value = default_value
         self.textinput = None
-        self.initialize(default_value, label)
+        # self.initialize(default_value, label)
+        widget_lst.append(self)
 
-    def initialize(self, default_value, label):
-        self.textinput = TextInput(value = default_value, title = label,
+    def initialize(self, widget_lst):
+        self.textinput = TextInput(value = self.value, title = self.label,
                                    disabled = True)
-        self.widget_lst.append(self.textinput)
+        widget_lst.append(self.textinput)
 
     def set_value(self, value):
-        self.textinput.value = str(value)
+        self.value = str(value)
+        if self.textinput is not None:
+            self.textinput.value = self.value

--- a/python/radio_button.py
+++ b/python/radio_button.py
@@ -20,14 +20,22 @@ from bokeh.models.widgets import RadioGroup
 
 class radiobutton():
     def __init__(self, widget_lst, default_value, label, inline = True):
-        self.widget_lst = widget_lst
+        self.label = label
+        self.default_value = default_value
+        self.inline = inline
         self.radiobutton = None
-        self.initialize(default_value, label, inline)
+        self.callback = None
+        # self.initialize(default_value, label, inline)
+        widget_lst.append(self)
 
-    def initialize(self, default_value, label, inline):
-        self.radiobutton = RadioGroup(active = default_value, labels = label,
-                                      inline = inline)
-        self.widget_lst.append(self.radiobutton)
+    def initialize(self, widget_lst):
+        self.radiobutton = RadioGroup(active = self.default_value, labels = self.label,
+                                      inline = self.inline)
+        widget_lst.append(self.radiobutton)
+        if self.callback is not None:
+            self.radiobutton.on_click(self.callback)
 
     def add_callback(self, callback):
-        self.radiobutton.on_click(callback)
+        self.callback = callback
+        if self.radiobutton is not None:
+            self.radiobutton.on_click(self.callback)

--- a/python/range_slider.py
+++ b/python/range_slider.py
@@ -33,8 +33,7 @@ class range_slider():
 
     def initialize(self, widget_lst):
         self.slider = RangeSlider(start = self.start, end = self.end, value = self.default,
-                                  step = self.step, title = self.label,
-                                  callback_throttle = self.callback_throttle)
+                                  step = self.step, title = self.label)
         widget_lst.append(self.slider)
         if self.callback is not None:
             self.slider.on_change('value', self.callback)

--- a/python/range_slider.py
+++ b/python/range_slider.py
@@ -21,18 +21,30 @@ from bokeh.models.widgets import RangeSlider
 class range_slider():
     def __init__(self, widget_lst, label, start, end, step, callback_throttle,
                  default):
-        self.widget_lst = widget_lst
+        self.label = label
+        self.start = start
+        self.end = end
+        self.step = step
+        self.callback_throttle = callback_throttle
+        self.default = default
         self.slider = None
-        self.initialize(label, start, end, step, callback_throttle, default)
+        self.callback = None
+        widget_lst.append(self)
 
-    def initialize(self, label, start, end, step, callback_throttle, default):
-        self.slider = RangeSlider(start = start, end = end, range = default,
-                                  step = step, title = label,
-                                  callback_throttle = callback_throttle)
-        self.widget_lst.append(self.slider)
+    def initialize(self, widget_lst):
+        self.slider = RangeSlider(start = self.start, end = self.end, value = self.default,
+                                  step = self.step, title = self.label,
+                                  callback_throttle = self.callback_throttle)
+        widget_lst.append(self.slider)
+        if self.callback is not None:
+            self.slider.on_change('value', self.callback)
 
     def add_callback(self, callback):
-        self.slider.on_change('range', callback)
+        self.callback = callback
+        if self.slider is not None:
+            self.slider.on_change('value', self.callback) #May not keep that one
 
     def set_value(self, value):
-        self.slider.range = value
+        if self.slider is not None:
+            self.slider.value = value
+        self.default = value

--- a/python/slider.py
+++ b/python/slider.py
@@ -21,18 +21,31 @@ from bokeh.models.widgets import Slider
 class slider():
     def __init__(self, widget_lst, label, start, end, step, callback_throttle,
                  default):
-        self.widget_lst = widget_lst
+        self.label = label
+        self.start = start
+        self.end = end
+        self.step = step
+        self.callback_throttle = callback_throttle
+        self.default = default
         self.slider = None
-        self.initialize(label, start, end, step, callback_throttle, default)
+        self.callback = None
+        # self.initialize(label, start, end, step, callback_throttle, default)
+        widget_lst.append(self)
 
-    def initialize(self, label, start, end, step, callback_throttle, default):
-        self.slider = Slider(start = start, end = end, value = default,
-                             step = step, title = label,
-                             callback_throttle = callback_throttle)
-        self.widget_lst.append(self.slider)
+    def initialize(self, widget_lst):
+        self.slider = Slider(start = self.start, end = self.end, value = self.default,
+                             step = self.step, title = self.label,
+                             callback_throttle = self.callback_throttle)
+        widget_lst.append(self.slider)
+        if self.callback is not None:
+            self.slider.on_change('value', self.callback)
 
     def add_callback(self, callback):
-        self.slider.on_change('value', callback)
+        self.callback = callback
+        if self.slider is not None:
+            self.slider.on_change('value', self.callback) #May not keep that one
 
     def set_value(self, value):
-        self.slider.value = value
+        if self.slider is not None:
+            self.slider.value = value
+        self.default = value

--- a/python/slider.py
+++ b/python/slider.py
@@ -34,8 +34,7 @@ class slider():
 
     def initialize(self, widget_lst):
         self.slider = Slider(start = self.start, end = self.end, value = self.default,
-                             step = self.step, title = self.label,
-                             callback_throttle = self.callback_throttle)
+                             step = self.step, title = self.label)
         widget_lst.append(self.slider)
         if self.callback is not None:
             self.slider.on_change('value', self.callback)

--- a/python/textbox.py
+++ b/python/textbox.py
@@ -21,16 +21,25 @@ from bokeh.models.widgets import TextInput
 
 class textbox:
     def __init__(self, widget_lst, default_value, label):
-        self.widget_lst = widget_lst
+        self.label = label
+        self.value = default_value
         self.textinput = None
-        self.initialize(default_value, label)
+        self.callback = None
+        # self.initialize(default_value, label)
+        widget_lst.append(self)
 
-    def initialize(self, default_value, label):
-        self.textinput = TextInput(value = default_value, title = label)
-        self.widget_lst.append(self.textinput)
-
+    def initialize(self, widget_lst):
+        self.textinput = TextInput(value = self.value, title = self.label)
+        widget_lst.append(self.textinput)
+        if self.callback is not None:
+            self.textinput.on_change('value', self.callback)
+            
     def add_callback(self, callback):
-        self.textinput.on_change('value', callback)
+        self.callback = callback
+        if self.textinput is not None:
+            self.textinput.on_change('value', self.callback)
 
     def set_value(self, value):
-        self.textinput.value = str(value)
+        self.value = str(value)
+        if self.textinput is not None:
+            self.textinput.value = self.value

--- a/python/time_sink_c.py
+++ b/python/time_sink_c.py
@@ -18,6 +18,7 @@
 
 from bokeh.models import ColumnDataSource, LabelSet
 from bokeh.plotting import figure
+from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
 
 class time_sink_c(bokeh_plot_config):
@@ -27,12 +28,11 @@ class time_sink_c(bokeh_plot_config):
     time_sink_c_proc class and streams to the frontend plot.
     """
 
-    def __init__(self, doc, plot_lst, process, is_message = False):
+    def __init__(self, plot_lst, proc, is_message = False, log_x = False, log_y = False,
+                   legend_list = utils.default_labels_f, update_time = 100):
         super(time_sink_c, self).__init__()
 
-        self.doc = doc
-        self.process = process
-        self.plot_lst = plot_lst
+        self.process = proc
 
         self.size = self.process.get_size()
         self.samp_rate = self.process.get_samp_rate()
@@ -40,36 +40,38 @@ class time_sink_c(bokeh_plot_config):
         self.nconnections = self.process.get_nconnections()
         self.is_message = is_message
 
-        self.tag_stream = None
-
         self.plot = None
         self.stream = None
-        self.lines = None
-        self.lines_markers = None
-        self.legend_list = None
         self.tags = None
         self.tags_marker = None
         self.tag_stream = None
-        self.update_callback = None
+        self.lines = None
+        self.lines_markers = None
+        self.legend_list = None
+
+        self.log_x = log_x
+        self.log_y = log_y
+        self.legend_list = legend_list[:]
+        self.update_time = update_time
+
+        plot_lst.append(self)
 
     def set_trigger_mode(self, trigger_mode, trigger_slope, level, delay,
                          channel, tag_key):
         self.process.set_trigger_mode(trigger_mode, trigger_slope, level,
                                       delay, channel, tag_key)
 
-    def initialize(self, log_x = False, log_y = False,
-                   legend_list = utils.default_labels_c, update_time = 100):
-        y_axis_type = 'log' if log_y else 'linear'
-        x_axis_type = 'log' if log_x else 'linear'
-        self.plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
+    def initialize(self, doc, plot_lst):
+        y_axis_type = 'log' if self.log_y else 'linear'
+        x_axis_type = 'log' if self.log_x else 'linear'
+        plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
                            active_scroll = 'ywheel_zoom',
                            y_axis_type = y_axis_type,
                            x_axis_type = x_axis_type,
                            output_backend="webgl")
         data = dict()
-        data['x'] = []
-
         tag_data = dict()
+        data['x'] = []
 
         if self.is_message:
             nconnection = 1
@@ -82,49 +84,81 @@ class time_sink_c(bokeh_plot_config):
             tag_data['y' + str(i)] = []
             tag_data['x' + str(i)] = []
 
-        for i in range(self.nconnections):
+        for i in range(nconnection):
             tag_data['tags' + str(i)] = []
 
-        self.stream = ColumnDataSource(data)
-        self.tag_stream = ColumnDataSource(tag_data)
-
+        stream = ColumnDataSource(data)
         self.lines = []
         self.lines_markers = []
-        self.legend_list = legend_list[:]
-        if not self.nconnections == 0:
-            self.tags = []
-            self.tags_marker = []
-        for i in range(2 * nconnection):
-            self.lines.append(self.plot.line(x = 'x', y = 'y' + str(i),
-                              source = self.stream, line_color = 'blue',
-                              legend = self.legend_list[i]))
-            self.lines_markers.append((None, None))
-
+        if self.tags_enabled:
+            tag_stream = ColumnDataSource(tag_data)
             if not self.is_message:
-                self.tags.append(LabelSet(x = 'x' + str(i), y = 'y' + str(i),
-                                          text = 'tags' + str(i // 2),
-                                          level = 'glyph', x_offset = -20,
-                                          y_offset = 5,
-                                          source = self.tag_stream,
-                                          text_font_style = 'bold',
-                                          text_font_size = '11pt',
-                                          render_mode = 'canvas'))
-                self.tags_marker.append(
-                        self.plot.triangle(x = 'x' + str(i), y = 'y' + str(i),
-                                           source = self.tag_stream, size = 10,
-                                           fill_color = 'red', ))
-                self.plot.add_layout(self.tags[i])
+                self.tags = []
+                self.tags_marker = []
+        else:
+            tag_stream = None
+        for i in range(2 * nconnection):
+            self.lines.append(plot.line(x = 'x', y = 'y' + str(i),
+                              source = stream, line_color = self.colors[i],
+                              line_width = self.widths[i], line_alpha=self.alphas[i],
+                              legend_label = self.legend_list[i]))
+            self.lines_markers.append((None, None))
+            if self.styles[i] == 'None':
+                self.lines[i].visible = False
+            else:
+                self.lines[i].glyph.line_dash = self.styles[i]
+            if self.tags_enabled:
+                if not self.is_message:
+                    self.tags.append(LabelSet(x = 'x' + str(i), y = 'y' + str(i),
+                                              text = 'tags' + str(i // 2),
+                                              level = 'glyph', x_offset = -20,
+                                              y_offset = 5,
+                                              source = tag_stream,
+                                              text_font_style = 'bold',
+                                              text_font_size = '11pt',
+                                              render_mode = 'canvas'))
+                    self.tags_marker.append(
+                            plot.triangle(x = 'x' + str(i), y = 'y' + str(i),
+                                               source = tag_stream, size = 10,
+                                               fill_color = 'red', line_color = 'red' )
+                           )
+                plot.add_layout(self.tags[i])
 
+        if self.title_text is not None:
+            plot.title.text = self.title_text
+        if self.y_range is not None:
+            plot.y_range = Range1d(self.y_range[0], self.y_range[1])
+        if self.x_range is not None:
+            plot.x_range = Range1d(self.x_range[0], self.x_range[1])
+        if self.y_label is not None:
+            plot.yaxis[0].axis_label = self.y_label
+        if self.x_label is not None:
+            plot.xaxis[0].axis_label = self.x_label
+        plot.xgrid.visible = self.x_grid
+        plot.ygrid.visible = self.y_grid
+        if self.en_axis_labels:
+            plot.xaxis[0].axis_label_text_color = '#000000'
+            plot.yaxis[0].axis_label_text_color = '#000000'
+        else:
+            plot.xaxis[0].axis_label_text_color = '#FFFFFF'
+            plot.yaxis[0].axis_label_text_color = '#FFFFFF'
+        plot.legend[0].visible = self.en_legend
+        plot.legend[0].click_policy = "hide"
+
+        self.plot = plot
+        self.stream = stream
         self.add_custom_tools()
-        self.plot_lst.append(self)
+        plot_lst.append(self)
 
-        if self.name:
-            self.set_title(self.name)
+        for i in range(nconnection):
+            self.use_line_marker(i,self.markers[i])
 
-        self.update_callback = self.doc.add_periodic_callback(self.update,
-                                                              update_time)
+        def callback():
+            self.update(tag_stream, stream)
 
-    def update(self):
+        doc.add_periodic_callback(callback, self.update_time)
+
+    def update(self, tag_stream, stream):
         # Call to receive from buffers
         output_items = self.process.get_plot_data()
         if not self.is_message:
@@ -172,8 +206,9 @@ class time_sink_c(bokeh_plot_config):
             if len(temp_x) > max_tag_size:
                 max_tag_size = len(temp_x)
 
-        self.stream.stream(new_data, rollover = self.size)
-        self.tag_stream.stream(new_tagged_data, rollover = max_tag_size)
+        stream.stream(new_data, rollover = self.size)
+        if tag_stream is not None:
+            tag_stream.stream(new_tagged_data, rollover = max_tag_size)
         return
 
     def values_x(self):
@@ -189,14 +224,16 @@ class time_sink_c(bokeh_plot_config):
             self.size = newsize
         self.set_x_axis([0, self.size / self.samp_rate])
 
-    def enable_tags(self, which = -1, en = True):
-        if which == -1:
-            for i in range(2 * self.nconnections):
-                self.enable_tags(i, en)
-        else:
-            if en:
-                self.tags[which].text_color = 'black'
-                self.tags_marker[which].visible = True
-            else:
-                self.tags[which].text_color = None
-                self.tags_marker[which].visible = False
+    # def enable_tags(self, which = -1, en = True):
+    #     if which == -1:
+    #         for i in range(2 * self.nconnections):
+    #             self.enable_tags(i, en)
+    #     else:
+    #         if en:
+    #             self.tags[which].text_color = 'black'
+    #             self.tags_marker[which].visible = True
+    #         else:
+    #             self.tags[which].text_color = None
+    #             self.tags_marker[which].visible = False
+    def enable_tags(self, which = -1, en = True): #This does not allow for selective enable, but the interface doesn't allow it either
+        self.tags_enabled = en

--- a/python/time_sink_f.py
+++ b/python/time_sink_f.py
@@ -18,6 +18,7 @@
 
 from bokeh.models import ColumnDataSource, LabelSet
 from bokeh.plotting import figure
+from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
 
 
@@ -28,12 +29,11 @@ class time_sink_f(bokeh_plot_config):
     time_sink_f_proc class and streams to the frontend plot.
     """
 
-    def __init__(self, doc, plot_lst, proc, is_message = False):
+    def __init__(self, plot_lst, proc, log_x = False, log_y = False,
+                   legend_list = utils.default_labels_f, update_time = 100, is_message = False):
         super(time_sink_f, self).__init__()
 
-        self.doc = doc
         self.process = proc
-        self.plot_lst = plot_lst
 
         self.size = self.process.get_size()
         self.samp_rate = self.process.get_samp_rate()
@@ -50,16 +50,22 @@ class time_sink_f(bokeh_plot_config):
         self.lines_markers = None
         self.legend_list = None
 
+        self.log_x = log_x
+        self.log_y = log_y
+        self.legend_list = legend_list[:]
+        self.update_time = update_time
+
+        plot_lst.append(self)
+
     def set_trigger_mode(self, trigger_mode, trigger_slope, level, delay,
                          channel, tag_key):
         self.process.set_trigger_mode(trigger_mode, trigger_slope, level,
                                       delay, channel, tag_key)
 
-    def initialize(self, log_x = False, log_y = False,
-                   legend_list = utils.default_labels_f, update_time = 100):
-        y_axis_type = 'log' if log_y else 'linear'
-        x_axis_type = 'log' if log_x else 'linear'
-        self.plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
+    def initialize(self, doc, plot_lst):
+        y_axis_type = 'log' if self.log_y else 'linear'
+        x_axis_type = 'log' if self.log_x else 'linear'
+        plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
                            active_scroll = 'ywheel_zoom',
                            y_axis_type = y_axis_type,
                            x_axis_type = x_axis_type,
@@ -80,47 +86,78 @@ class time_sink_f(bokeh_plot_config):
             tag_data['y' + str(i)] = []
             if not self.is_message:
                 tag_data['tags' + str(i)] = []
-        self.stream = ColumnDataSource(data)
-        self.tag_stream = ColumnDataSource(tag_data)
-
-        self.lines = []
+        stream = ColumnDataSource(data)
+        self.lines = []  #TODO: de self ize
         self.lines_markers = []
-        self.legend_list = legend_list[:]
-        if not self.is_message:
-            self.tags = []
-            self.tags_marker = []
-        for i in range(nconnection):
-            self.lines.append(self.plot.line(x = 'x', y = 'y' + str(i),
-                              source = self.stream, line_color = 'blue',
-                              legend = self.legend_list[i]))
-            self.lines_markers.append((None, None))
-
+        if self.tags_enabled:
+            tag_stream = ColumnDataSource(tag_data)
             if not self.is_message:
-                self.tags.append(LabelSet(x = 'x' + str(i), y = 'y' + str(i),
-                                          text = 'tags' + str(i),
-                                          level = 'glyph', x_offset = -20,
-                                          y_offset = 5,
-                                          source = self.tag_stream,
-                                          text_font_style = 'bold',
-                                          text_font_size = '11pt',
-                                          render_mode = 'canvas'))
-                self.tags_marker.append(
-                        self.plot.triangle(x = 'x' + str(i), y = 'y' + str(i),
-                                           source = self.tag_stream, size = 10,
-                                           fill_color = 'red', line_color = 'red')
-                        )
+                self.tags = []
+                self.tags_marker = []
+        else:
+            tag_stream = None
+        for i in range(nconnection):
+            self.lines.append(plot.line(x = 'x', y = 'y' + str(i),
+                              source = stream, line_color = self.colors[i],
+                              line_width = self.widths[i], line_alpha=self.alphas[i],
+                              legend_label = self.legend_list[i]))
+            self.lines_markers.append((None, None))
+            if self.styles[i] == 'None':
+                self.lines[i].visible = False
+            else:
+                self.lines[i].glyph.line_dash = self.styles[i]
+            if self.tags_enabled:
+                if not self.is_message:
+                    self.tags.append(LabelSet(x = 'x' + str(i), y = 'y' + str(i),
+                                              text = 'tags' + str(i),
+                                              level = 'glyph', x_offset = -20,
+                                              y_offset = 5,
+                                              source = tag_stream,
+                                              text_font_style = 'bold',
+                                              text_font_size = '11pt',
+                                              render_mode = 'canvas'))
+                    self.tags_marker.append(
+                            plot.triangle(x = 'x' + str(i), y = 'y' + str(i),
+                                               source = tag_stream, size = 10,
+                                               fill_color = 'red', line_color = 'red')
+                            )
 
-                self.plot.add_layout(self.tags[i])
+                    plot.add_layout(self.tags[i])
+        if self.title_text is not None:
+            plot.title.text = self.title_text
+        if self.y_range is not None:
+            plot.y_range = Range1d(self.y_range[0], self.y_range[1])
+        if self.x_range is not None:
+            plot.x_range = Range1d(self.x_range[0], self.x_range[1])
+        if self.y_label is not None:
+            plot.yaxis[0].axis_label = self.y_label
+        if self.x_label is not None:
+            plot.xaxis[0].axis_label = self.x_label
+        plot.xgrid.visible = self.x_grid
+        plot.ygrid.visible = self.y_grid
+        if self.en_axis_labels:
+            plot.xaxis[0].axis_label_text_color = '#000000'
+            plot.yaxis[0].axis_label_text_color = '#000000'
+        else:
+            plot.xaxis[0].axis_label_text_color = '#FFFFFF'
+            plot.yaxis[0].axis_label_text_color = '#FFFFFF'
+        plot.legend[0].visible = self.en_legend
+        plot.legend[0].click_policy = "hide"
 
+        self.plot = plot
+        self.stream = stream
         self.add_custom_tools()
-        self.plot_lst.append(self)
+        plot_lst.append(self)
 
-        if self.name:
-            self.set_title(self.name)
+        for i in range(nconnection):
+            self.use_line_marker(i,self.markers[i])
 
-        self.doc.add_periodic_callback(self.update, update_time)
+        def callback():
+            self.update(tag_stream, stream)
 
-    def update(self):
+        doc.add_periodic_callback(callback, self.update_time)
+
+    def update(self, tag_stream, stream):
         # Call to receive from buffers
         output_items = self.process.get_plot_data()
         if not self.is_message:
@@ -165,8 +202,9 @@ class time_sink_f(bokeh_plot_config):
             new_tagged_data['tags' + str(i)] = temp_tags
             if len(temp_x) > max_tag_size:
                 max_tag_size = len(temp_x)
-        self.stream.stream(new_data, rollover = self.size)
-        self.tag_stream.stream(new_tagged_data, rollover = max_tag_size)
+        stream.stream(new_data, rollover = self.size)
+        if tag_stream is not None:
+            tag_stream.stream(new_tagged_data, rollover = max_tag_size)
         return
 
     def values_x(self):
@@ -182,14 +220,16 @@ class time_sink_f(bokeh_plot_config):
             self.size = newsize
         self.set_x_axis([0, self.size / self.samp_rate])
 
-    def enable_tags(self, which = -1, en = True):
-        if which == -1:
-            for i in range(self.nconnections):
-                self.enable_tags(i, en)
-        else:
-            if en:
-                self.tags[which].text_color = 'black'
-                self.tags_marker[which].visible = True
-            else:
-                self.tags[which].text_color = None
-                self.tags_marker[which].visible = False
+    # def enable_tags(self, which = -1, en = True):
+    #     if which == -1:
+    #         for i in range(self.nconnections):
+    #             self.enable_tags(i, en)
+    #     else:
+    #         if en:
+    #             self.tags[which].text_color = 'black'
+    #             self.tags_marker[which].visible = True
+    #         else:
+    #             self.tags[which].text_color = None
+    #             self.tags_marker[which].visible = False
+    def enable_tags(self, which = -1, en = True): #This does not allow for selective enable, but the interface doesn't allow it either
+        self.tags_enabled = en

--- a/python/utils.py
+++ b/python/utils.py
@@ -35,7 +35,7 @@ default_labels_c = ["Re{{Data {0}}}".format(i // 2) if i % 2 == 0
 
 
 
-def run_server(tb):
+def run_server(tb, sizing_mode="fixed", widget_placement=(0,0), window_size=(1000,1000)):
     port = subprocess.check_output([os.path.abspath(
         os.path.dirname(__file__)) + "/scripts/check-port.sh"])
 
@@ -58,11 +58,11 @@ def run_server(tb):
         if widget_list:
             input_t = bokehgui.bokeh_layout.widgetbox(widget_list)
             widgetbox = bokehgui.bokeh_layout.WidgetLayout(input_t)
-            widgetbox.set_layout(*((0, 0)))
+            widgetbox.set_layout(*widget_placement)
             list_obj = [widgetbox] + plot_list
         else:
             list_obj = plot_list
-        layout_t = bokehgui.bokeh_layout.create_layout(list_obj, "fixed")
+        layout_t = bokehgui.bokeh_layout.create_layout(list_obj, sizing_mode, window_size)
         print(layout_t)
         doc.add_root(layout_t)
 

--- a/python/utils.py
+++ b/python/utils.py
@@ -52,7 +52,6 @@ def run_server(tb, sizing_mode="fixed", widget_placement=(0,0), window_size=(100
         widget_list = []
         for i in tb.plot_lst:
             i.initialize(doc, plot_list )
-        print(plot_list)
         for i in tb.widget_lst:
             i.initialize(widget_list )
         if widget_list:
@@ -63,7 +62,6 @@ def run_server(tb, sizing_mode="fixed", widget_placement=(0,0), window_size=(100
         else:
             list_obj = plot_list
         layout_t = bokehgui.bokeh_layout.create_layout(list_obj, sizing_mode, window_size)
-        print(layout_t)
         doc.add_root(layout_t)
 
 

--- a/python/vec_sink_c.py
+++ b/python/vec_sink_c.py
@@ -18,6 +18,7 @@
 
 from bokeh.models import ColumnDataSource, CustomJS
 from bokeh.plotting import figure
+from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
 
 
@@ -28,12 +29,11 @@ class vec_sink_c(bokeh_plot_config):
     vec_sink_c_proc class and streams to the frontend plot.
     """
 
-    def __init__(self, doc, plot_lst, process, is_message = False):
+    def __init__(self, plot_lst, process, legend_list = utils.default_labels_c,
+                   update_time = 100, is_message = False):
         super(vec_sink_c, self).__init__()
 
-        self.doc = doc
         self.process = process
-        self.plot_lst = plot_lst
 
         self.size = self.process.get_vlen()
         self.x_values = [i for i in range(self.size)]
@@ -43,17 +43,21 @@ class vec_sink_c(bokeh_plot_config):
         self.is_message = is_message
         self.plot = None
         self.stream = None
-        self.max_hold = None
+        self.max_hold_plot = None
+        self.max_hold = False
         self.legend_list = None
         self.lines_markers = None
         self.lines = None
+        self.legend_list = legend_list[:]
+        self.update_time = update_time
+
+        plot_lst.append(self)
 
     # def set_trigger_mode(self, trigger_mode, level, channel, tag_key):
     #     self.process.set_trigger_mode(trigger_mode, level, channel, tag_key)
 
-    def initialize(self, legend_list = utils.default_labels_c,
-                   update_time = 100):
-        self.plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
+    def initialize(self, doc, plot_lst):
+        plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
                            active_scroll = 'ywheel_zoom',
                            output_backend="webgl")
         data = dict()
@@ -65,34 +69,86 @@ class vec_sink_c(bokeh_plot_config):
         for i in range(2 * nconn):
             data['y' + str(i)] = []
 
-        self.stream = ColumnDataSource(data)
+        stream = ColumnDataSource(data)
 
         self.lines = []
         self.lines_markers = []
-        self.legend_list = legend_list[:]
         print(self.legend_list)
         for i in range(2 * nconn):
-            self.lines.append(self.plot.line(x = 'x', y = 'y' + str(i),
-                                             source = self.stream,
-                                             line_color = 'blue',
-                                             legend = self.legend_list[i]))
+            self.lines.append(plot.line(x = 'x', y = 'y' + str(i),
+                                             source = stream,
+                                             line_color = self.colors[i],
+                                             line_width = self.widths[i], line_alpha=self.alphas[i],
+                                             legend_label = self.legend_list[i]))
             self.lines_markers.append((None, None))
+            if self.styles[i] == 'None':
+                self.lines[i].visible = False
+            else:
+                self.lines[i].glyph.line_dash = self.styles[i]
 
+        if self.title_text is not None:
+            plot.title.text = self.title_text
+        if self.y_range is not None:
+            plot.y_range = Range1d(self.y_range[0], self.y_range[1])
+        if self.x_range is not None:
+            plot.x_range = Range1d(self.x_range[0], self.x_range[1])
+        if self.y_label is not None:
+            plot.yaxis[0].axis_label = self.y_label
+        if self.x_label is not None:
+            plot.xaxis[0].axis_label = self.x_label
+        plot.xgrid.visible = self.x_grid
+        plot.ygrid.visible = self.y_grid
+        if self.en_axis_labels:
+            plot.xaxis[0].axis_label_text_color = '#000000'
+            plot.yaxis[0].axis_label_text_color = '#000000'
+        else:
+            plot.xaxis[0].axis_label_text_color = '#FFFFFF'
+            plot.yaxis[0].axis_label_text_color = '#FFFFFF'
+        plot.legend[0].visible = self.en_legend
+        plot.legend[0].click_policy = "hide"
+
+        self.plot = plot
+        self.stream = stream
         self.add_custom_tools()
 
         # Add max-hold plot
-        self.max_hold = None
-        self.enable_max_hold(False)
+        max_hold_source = ColumnDataSource(
+                data = dict(x = range(self.size),
+                            y = [float("-inf")] * self.size))
+        self.max_hold_plot = plot.line(x = 'x', y = 'y',
+                                       source = max_hold_source,
+                                       line_color = 'green',
+                                       line_dash = 'dotdash',
+                                       legend_label= 'Max')
+        callback = CustomJS(args = dict(max_hold_source = max_hold_source),
+                            code = """
+                        var no_of_elem = cb_obj.data.x.length;
+                        var data = cb_obj.data;
+                        nconn = Object.getOwnPropertyNames(data).length -1;
+                        var max_data = max_hold_source.data;
+                        max_data.x = cb_obj.data.x;
+
+                        for(n = 0; n < nconn; n++) {
+                               for (i = 0; i < no_of_elem; i++) {
+                                   if(max_data['y'][i] < data['y'+n][i]) {
+                                       max_data['y'][i] = data['y'+n][i]
+                                   }
+                               }
+                        }
+                        max_hold_source.change.emit();
+                        """)
+        stream.js_on_change("streaming", callback)
+        self.max_hold_plot.visible = self.max_hold
         # max-hold plot done
 
-        self.plot_lst.append(self)
+        plot_lst.append(self)
 
-        if self.name:
-            self.set_title(self.name)
+        def callback():
+            self.update(stream)
 
-        self.doc.add_periodic_callback(self.update, update_time)
+        doc.add_periodic_callback(callback, self.update_time)
 
-    def update(self):
+    def update(self, stream):
         # Call to receive from buffers
         output_items = self.process.get_plot_data()
         # print("updating: {}, should be of size {}".format(output_items, output_items.shape))
@@ -106,7 +162,7 @@ class vec_sink_c(bokeh_plot_config):
             for i in range(2* self.nconnections): # 2 channels per input stream (complex)
                 new_data['y' + str(i)] = output_items[i]
             new_data['x'] = self.x_values
-            self.stream.stream(new_data, rollover = self.size)
+            stream.stream(new_data, rollover = self.size)
         return
 
     def set_x_values(self, values):
@@ -120,35 +176,6 @@ class vec_sink_c(bokeh_plot_config):
 
 
     def enable_max_hold(self, en = True):
-        if self.max_hold is None:
-            max_hold_source = ColumnDataSource(
-                    data = dict(x = range(self.size),
-                                y = [float("-inf")] * self.size))
-            self.max_hold = self.plot.line(x = 'x', y = 'y',
-                                           source = max_hold_source,
-                                           line_color = 'green',
-                                           line_dash = 'dotdash',
-                                           line_alpha = 0)
-            callback = CustomJS(args = dict(max_hold_source = max_hold_source),
-                                code = """
-                            var no_of_elem = cb_obj.data.x.length;
-                            var data = cb_obj.data;
-                            nconn = Object.getOwnPropertyNames(data).length -1;
-                            var max_data = max_hold_source.data;
-                            max_data.x = cb_obj.data.x;
-
-                            for(n = 0; n < nconn; n++) {
-                                   for (i = 0; i < no_of_elem; i++) {
-                                       if(max_data['y'][i] < data['y'+n][i]) {
-                                           max_data['y'][i] = data['y'+n][i]
-                                       }
-                                   }
-                            }
-                            max_hold_source.change.emit();
-                            """)
-            self.stream.js_on_change("streaming", callback)
-        if en:
-            self.max_hold.glyph.line_alpha = 1
-
-        else:
-            self.max_hold.glyph.line_alpha = 0
+        self.max_hold = en
+        if self.max_hold_plot:
+            self.max_hold_plot.visible = self.max_hold

--- a/python/vec_sink_c.py
+++ b/python/vec_sink_c.py
@@ -73,7 +73,6 @@ class vec_sink_c(bokeh_plot_config):
 
         self.lines = []
         self.lines_markers = []
-        print(self.legend_list)
         for i in range(2 * nconn):
             self.lines.append(plot.line(x = 'x', y = 'y' + str(i),
                                              source = stream,

--- a/python/vec_sink_c.py
+++ b/python/vec_sink_c.py
@@ -123,12 +123,12 @@ class vec_sink_c(bokeh_plot_config):
                             code = """
                         var no_of_elem = cb_obj.data.x.length;
                         var data = cb_obj.data;
-                        nconn = Object.getOwnPropertyNames(data).length -1;
+                        const nconn = Object.getOwnPropertyNames(data).length -1;
                         var max_data = max_hold_source.data;
                         max_data.x = cb_obj.data.x;
 
-                        for(n = 0; n < nconn; n++) {
-                               for (i = 0; i < no_of_elem; i++) {
+                        for(let n = 0; n < nconn; n++) {
+                               for (let i = 0; i < no_of_elem; i++) {
                                    if(max_data['y'][i] < data['y'+n][i]) {
                                        max_data['y'][i] = data['y'+n][i]
                                    }

--- a/python/vec_sink_f.py
+++ b/python/vec_sink_f.py
@@ -123,12 +123,12 @@ class vec_sink_f(bokeh_plot_config):
                             code = """
                         var no_of_elem = cb_obj.data.x.length;
                         var data = cb_obj.data;
-                        nconn = Object.getOwnPropertyNames(data).length -1;
+                        const nconn = Object.getOwnPropertyNames(data).length -1;
                         var max_data = max_hold_source.data;
                         max_data.x = cb_obj.data.x;
 
-                        for(n = 0; n < nconn; n++) {
-                               for (i = 0; i < no_of_elem; i++) {
+                        for(let n = 0; n < nconn; n++) {
+                               for (let i = 0; i < no_of_elem; i++) {
                                    if(max_data['y'][i] < data['y'+n][i]) {
                                        max_data['y'][i] = data['y'+n][i]
                                    }

--- a/python/vec_sink_f.py
+++ b/python/vec_sink_f.py
@@ -18,6 +18,7 @@
 
 from bokeh.models import ColumnDataSource, CustomJS
 from bokeh.plotting import figure
+from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
 
 
@@ -28,12 +29,11 @@ class vec_sink_f(bokeh_plot_config):
     vec_sink_f_proc class and streams to the frontend plot.
     """
 
-    def __init__(self, doc, plot_lst, process, is_message = False):
+    def __init__(self, plot_lst, process, legend_list = utils.default_labels_f,
+                   update_time = 100, is_message = False):
         super(vec_sink_f, self).__init__()
 
-        self.doc = doc
         self.process = process
-        self.plot_lst = plot_lst
 
         self.size = self.process.get_vlen()
         self.x_values = [i for i in range(self.size)]
@@ -43,17 +43,21 @@ class vec_sink_f(bokeh_plot_config):
         self.is_message = is_message
         self.plot = None
         self.stream = None
-        self.max_hold = None
+        self.max_hold_plot = None
+        self.max_hold = False
         self.legend_list = None
         self.lines_markers = None
         self.lines = None
+        self.legend_list = legend_list[:]
+        self.update_time = update_time
+
+        plot_lst.append(self)
 
     # def set_trigger_mode(self, trigger_mode, level, channel, tag_key):
     #     self.process.set_trigger_mode(trigger_mode, level, channel, tag_key)
 
-    def initialize(self, legend_list = utils.default_labels_f,
-                   update_time = 100):
-        self.plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
+    def initialize(self, doc, plot_lst):
+        plot = figure(tools = utils.default_tools(), active_drag = 'ypan',
                            active_scroll = 'ywheel_zoom',
                            output_backend="webgl")
         data = dict()
@@ -65,33 +69,85 @@ class vec_sink_f(bokeh_plot_config):
         for i in range(nconn):
             data['y' + str(i)] = []
 
-        self.stream = ColumnDataSource(data)
+        stream = ColumnDataSource(data)
 
         self.lines = []
         self.lines_markers = []
-        self.legend_list = legend_list[:]
         for i in range(self.nconnections):
-            self.lines.append(self.plot.line(x = 'x', y = 'y' + str(i),
-                                             source = self.stream,
-                                             line_color = 'blue',
-                                             legend = self.legend_list[i]))
+            self.lines.append(plot.line(x = 'x', y = 'y' + str(i),
+                                             source = stream,
+                                             line_color = self.colors[i],
+                                             line_width = self.widths[i], line_alpha=self.alphas[i],
+                                             legend_label = self.legend_list[i]))
             self.lines_markers.append((None, None))
+            if self.styles[i] == 'None':
+                self.lines[i].visible = False
+            else:
+                self.lines[i].glyph.line_dash = self.styles[i]
 
+        if self.title_text is not None:
+            plot.title.text = self.title_text
+        if self.y_range is not None:
+            plot.y_range = Range1d(self.y_range[0], self.y_range[1])
+        if self.x_range is not None:
+            plot.x_range = Range1d(self.x_range[0], self.x_range[1])
+        if self.y_label is not None:
+            plot.yaxis[0].axis_label = self.y_label
+        if self.x_label is not None:
+            plot.xaxis[0].axis_label = self.x_label
+        plot.xgrid.visible = self.x_grid
+        plot.ygrid.visible = self.y_grid
+        if self.en_axis_labels:
+            plot.xaxis[0].axis_label_text_color = '#000000'
+            plot.yaxis[0].axis_label_text_color = '#000000'
+        else:
+            plot.xaxis[0].axis_label_text_color = '#FFFFFF'
+            plot.yaxis[0].axis_label_text_color = '#FFFFFF'
+        plot.legend[0].visible = self.en_legend
+        plot.legend[0].click_policy = "hide"
+
+        self.plot = plot
+        self.stream = stream
         self.add_custom_tools()
 
         # Add max-hold plot
-        self.max_hold = None
-        self.enable_max_hold(False)
+        max_hold_source = ColumnDataSource(
+                data = dict(x = range(self.size),
+                            y = [float("-inf")] * self.size))
+        self.max_hold_plot = plot.line(x = 'x', y = 'y',
+                                       source = max_hold_source,
+                                       line_color = 'green',
+                                       line_dash = 'dotdash',
+                                       legend_label= 'Max')
+        callback = CustomJS(args = dict(max_hold_source = max_hold_source),
+                            code = """
+                        var no_of_elem = cb_obj.data.x.length;
+                        var data = cb_obj.data;
+                        nconn = Object.getOwnPropertyNames(data).length -1;
+                        var max_data = max_hold_source.data;
+                        max_data.x = cb_obj.data.x;
+
+                        for(n = 0; n < nconn; n++) {
+                               for (i = 0; i < no_of_elem; i++) {
+                                   if(max_data['y'][i] < data['y'+n][i]) {
+                                       max_data['y'][i] = data['y'+n][i]
+                                   }
+                               }
+                        }
+                        max_hold_source.change.emit();
+                        """)
+        stream.js_on_change("streaming", callback)
+        self.max_hold_plot.visible = self.max_hold
         # max-hold plot done
 
-        self.plot_lst.append(self)
+        plot_lst.append(self)
 
-        if self.name:
-            self.set_title(self.name)
+        def callback():
+            self.update(stream)
 
-        self.doc.add_periodic_callback(self.update, update_time)
+        doc.add_periodic_callback(callback, self.update_time)
 
-    def update(self):
+    def update(self, stream):
         # Call to receive from buffers
         output_items = self.process.get_plot_data()
         # print("updating: {}, should be of size {}".format(output_items, output_items.shape))
@@ -105,7 +161,7 @@ class vec_sink_f(bokeh_plot_config):
             for i in range(self.nconnections):
                 new_data['y' + str(i)] = output_items[i]
             new_data['x'] = self.x_values
-            self.stream.stream(new_data, rollover = self.size)
+            stream.stream(new_data, rollover = self.size)
         return
 
     def set_x_values(self, values):
@@ -119,35 +175,6 @@ class vec_sink_f(bokeh_plot_config):
 
 
     def enable_max_hold(self, en = True):
-        if self.max_hold is None:
-            max_hold_source = ColumnDataSource(
-                    data = dict(x = range(self.size),
-                                y = [float("-inf")] * self.size))
-            self.max_hold = self.plot.line(x = 'x', y = 'y',
-                                           source = max_hold_source,
-                                           line_color = 'green',
-                                           line_dash = 'dotdash',
-                                           line_alpha = 0)
-            callback = CustomJS(args = dict(max_hold_source = max_hold_source),
-                                code = """
-                            var no_of_elem = cb_obj.data.x.length;
-                            var data = cb_obj.data;
-                            nconn = Object.getOwnPropertyNames(data).length -1;
-                            var max_data = max_hold_source.data;
-                            max_data.x = cb_obj.data.x;
-
-                            for(n = 0; n < nconn; n++) {
-                                   for (i = 0; i < no_of_elem; i++) {
-                                       if(max_data['y'][i] < data['y'+n][i]) {
-                                           max_data['y'][i] = data['y'+n][i]
-                                       }
-                                   }
-                            }
-                            max_hold_source.change.emit();
-                            """)
-            self.stream.js_on_change("streaming", callback)
-        if en:
-            self.max_hold.glyph.line_alpha = 1
-
-        else:
-            self.max_hold.glyph.line_alpha = 0
+        self.max_hold = en
+        if self.max_hold_plot:
+            self.max_hold_plot.visible = self.max_hold

--- a/python/waterfall_sink_c.py
+++ b/python/waterfall_sink_c.py
@@ -29,12 +29,13 @@ class waterfall_sink_c(bokeh_plot_config):
     waterfall_sink_c_proc class and streams to the frontend plot.
     """
 
-    def __init__(self, doc, plot_lst, proc, is_message = False):
+    def __init__(self, plot_lst, proc, legend_list = utils.default_labels_f,
+                   update_time = 100, values_range = (-200, 10),
+                   time_per_sample = 0.1, number_of_samples = 200,
+                   palette = 'Inferno', is_message = False):
         super(waterfall_sink_c, self).__init__()
 
-        self.doc = doc
         self.process = proc
-        self.plot_lst = plot_lst
 
         self.size = self.process.get_size()
         self.wintype = self.process.get_wintype()
@@ -44,8 +45,8 @@ class waterfall_sink_c(bokeh_plot_config):
         self.bw = self.process.get_bandwidth()
 
         self.is_message = is_message
-        self.nrows = 1000
-        self.time_per_sample = 0.1
+        self.nrows = number_of_samples
+        self.time_per_sample = time_per_sample
         self.frequency_range = None
         self.set_frequency_range(self.fc, self.bw, set_y_axis = False,
                                  notify_process = False)
@@ -53,38 +54,41 @@ class waterfall_sink_c(bokeh_plot_config):
         self.plot = None
         self.waterfall_renderer = None
 
-    def initialize(self, legend_list = utils.default_labels_f,
-                   update_time = 100, values_range = (-200, 10),
-                   time_per_sample = 0.1, number_of_samples = 1000,
-                   palette = 'Inferno'):
-        self.nrows = number_of_samples
-        self.time_per_sample = time_per_sample
+        self.legend_list = legend_list[:]
+        self.update_time = update_time
+        self.values_range = values_range
+        self.palette = palette
 
-        self.plot = figure(tools = ['save', 'reset'],
+        plot_lst.append(self)
+
+    def initialize(self, doc, plot_lst):
+
+        plot = figure(tools = ['save', 'reset'],
                            y_range = [0, self.nrows],
                            x_range = [self.frequency_range[0],
                                       self.frequency_range[-1]],
                                       output_backend="webgl")
-        self.plot.yaxis.formatter = FuncTickFormatter(code = """
+        plot.yaxis.formatter = FuncTickFormatter(code = """
                            return (%s - tick)*%s
-                           """ % (self.nrows, time_per_sample))
+                           """ % (self.nrows, self.time_per_sample))
 
         self.waterfall_renderer = []
         for i in range(self.nconnections):
             self.waterfall_renderer.append(
-                WaterfallRenderer(palette = utils.PALETTES[palette],
+                WaterfallRenderer(palette = utils.PALETTES[self.palette],
                                   time_length = self.nrows,
                                   fft_length = self.size,
-                                  min_value = values_range[0],
-                                  max_value = values_range[-1]))
-            self.plot.renderers.append(self.waterfall_renderer[i])
+                                  min_value = self.values_range[0],
+                                  max_value = self.values_range[-1]))
+            plot.renderers.append(self.waterfall_renderer[i])
 
-        self.plot_lst.append(self)
+        self.plot = plot
+        plot_lst.append(self)
 
-        if self.name:
-            self.set_title(self.name)
+        def callback():
+            self.update( )
 
-        self.doc.add_periodic_callback(self.update, update_time)
+        doc.add_periodic_callback(callback, self.update_time)
 
     def update(self):
         output_items = self.process.get_plot_data()


### PR DESCRIPTION
This uses a new event loop management to handle the removal of the previous one in bokeh 2.0. 

See [these discussions](https://github.com/gnuradio/gr-bokehgui/issues/28).

To be used, it needs changes to the gnuradio side so they will stay in a separate branch from maint-3.8 until the related PR is merged.

Allows compatibility with bokeh up to 2.0.2, the waterfall display crashes with later versions.