### PR TITLE
Support for bokeh up to 2.2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ ENV/
 *.swp
 
 .unittests/
+
+examples/test_bokehgui.py

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ The module was irst developed as a part of Google Summer of Code 2017 by Kartik 
 
 ## Dependency
 1. GNU Radio 3.8.3
-2. [Bokeh library](https://docs.bokeh.org/en/2.0.2/)
-   (Tested on v1.4.0 and 2.0.2) (later versions cause the waterfall display to crash)
+2. [Bokeh library between 2.1.0 and 2.2.3](https://docs.bokeh.org/en/2.2.3/) (earlier and later versions cause the waterfall display to crash, the rest is fine)
 
 ## Installation
 
@@ -25,7 +24,7 @@ $ git clone https://github.com/gnuradio/gr-bokehgui.git
 3. Build with CMake:
 ```
 $ cd gr-bokehgui/
-$ git checkout tags/compatbokeh2.0
+$ git checkout tags/compatbokeh2.2
 $ mkdir build
 $ cd build/
 $ cmake ../

--- a/examples/test_bokehgui.grc
+++ b/examples/test_bokehgui.grc
@@ -1071,7 +1071,7 @@ blocks:
     bus_structure: null
     coordinate: [602, 356]
     rotation: 0
-    state: true
+    state: enabled
 - name: bokehgui_waterfall_sink_x_0_0
   id: bokehgui_waterfall_sink_x
   parameters:
@@ -1104,7 +1104,7 @@ blocks:
     bus_structure: null
     coordinate: [608, 731]
     rotation: 0
-    state: true
+    state: enabled
 - name: fft_vxx_0
   id: fft_vxx
   parameters:

--- a/python/plots/waterfall.ts
+++ b/python/plots/waterfall.ts
@@ -54,8 +54,8 @@ export class WaterfallRendererView extends RendererView {
     this.connect(this.model.change, this.request_render)
   }
 
-  render(): void {
-    const ctx = this.plot_view.canvas_view.ctx
+  protected _render(): void {
+    const ctx = this.layer.ctx
     ctx.save()
 
     const smoothing = ctx.getImageSmoothingEnabled()


### PR DESCRIPTION
Modify the waterfall display to accomodate the BokehJS changes between 2.0.2 and 2.2.0.
Everything else is still compatible with earlier versions, and also later ones.