### PR TITLE
Allows used port checking with both netstat and ss

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The module was first developed as a part of Google Summer of Code 2017 by Kartik
 1. GNU Radio 3.9.5 or 3.10
 2. [Bokeh library above 2.3.1](https://docs.bokeh.org/en/2.3.2/) (earlier versions cause the waterfall display to crash)
 3. NodeJS >= 14
+4. Netstat or ss to check open ports (optionnal)
 
 ## Installation
 ### Using source code

--- a/python/scripts/check-port.sh
+++ b/python/scripts/check-port.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-netstat -netul | awk '{ print $4 }' | awk -F':' '{ print $NF }' | tail -n +3 > temp_netstat
+# Use netstat if available, else try ss command
+if ! command -v netstat &> /dev/null
+then
+	ss -netul | awk '{ print $5 }' | awk -F':' '{ print $NF }' | tail -n +3 > temp_netstat
+else
+	netstat -netul | awk '{ print $4 }' | awk -F':' '{ print $NF }' | tail -n +3 > temp_netstat
+fi
 
 TEMP=temp_netstat
-port_server_assign=0
+port_server_assign=5006
 
 for port in {5006..70000}
 do

--- a/python/utils.py
+++ b/python/utils.py
@@ -36,8 +36,8 @@ default_labels_c = ["Re{{Data {0}}}".format(i // 2) if i % 2 == 0
 
 
 def run_server(tb, sizing_mode="fixed", widget_placement=(0,0), window_size=(1000,1000)):
-    port = subprocess.check_output([os.path.abspath(
-        os.path.dirname(__file__)) + "/scripts/check-port.sh"])
+    port = int(subprocess.check_output([os.path.abspath(
+        os.path.dirname(__file__)) + "/scripts/check-port.sh"]))
 
 
     # app = ba.Application(ba.handlers.ScriptHandler(os.path.abspath(os.path.dirname(__file__)) + "/plots/bokehgui.py"]))
@@ -67,7 +67,7 @@ def run_server(tb, sizing_mode="fixed", widget_placement=(0,0), window_size=(100
 
     handler = bh.FunctionHandler(make_doc)
     app = ba.Application(handler)
-    server = Server(app)
+    server = Server(app, port=port, allow_websocket_origin=["*"])
     print(f"Please open a browser at the following address: localhost:{server.port}")
     server.run_until_shutdown()
     return #server_proc, str(int(port))


### PR DESCRIPTION
Also restores port auto selection, sensible default port in case neither is available, and wildcard host connection.

Mainly uses the snipped [provided](https://github.com/gnuradio/gr-bokehgui/issues/44) by @kb3gtn
And also restores the regression [mentioned](https://github.com/gnuradio/gr-bokehgui/issues/45) by @tkircher.