### PR TITLE
trailing dot not needed beyond minor version

### DIFF
--- a/.github/workflows/withAptitude.yml
+++ b/.github/workflows/withAptitude.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         gr: [3.9., 3.10.]
-        bokeh: [2.3.1., 2.x.]
+        bokeh: [2.3.1, 2.x.]
       fail-fast: false
        
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
Small things matter.  The trailing dot is only needed up to and including the minor version (as in 2.x.) but not beyond it, (as in 2.3.1)