### PR TITLE
add includes for boost::bind + namespace for boost::placeholders

### DIFF
--- a/include/bokehgui/base_sink.h
+++ b/include/bokehgui/base_sink.h
@@ -23,10 +23,13 @@
 #define INCLUDED_BOKEHGUI_BASE_SINK_PROC_H
 
 #include <queue>
+#include <boost/bind/bind.hpp>
 #include <bokehgui/api.h>
 #include <gnuradio/sync_block.h>
 #include <bokehgui/trigger_mode.h>
 #include <volk/volk.h>
+
+using namespace boost::placeholders;
 
 namespace gr {
   namespace bokehgui {

--- a/lib/freq_sink_c_proc_impl.cc
+++ b/lib/freq_sink_c_proc_impl.cc
@@ -22,7 +22,10 @@
 #endif
 
 #include <string.h>
+#include <boost/bind/bind.hpp>
 #include "freq_sink_c_proc_impl.h"
+
+using namespace boost::placeholders;
 
 namespace gr {
   namespace bokehgui {

--- a/lib/freq_sink_f_proc_impl.cc
+++ b/lib/freq_sink_f_proc_impl.cc
@@ -22,7 +22,10 @@
 #endif
 
 #include <string.h>
+#include <boost/bind/bind.hpp>
 #include "freq_sink_f_proc_impl.h"
+
+using namespace boost::placeholders;
 
 namespace gr {
   namespace bokehgui {

--- a/lib/vec_sink_c_proc_impl.cc
+++ b/lib/vec_sink_c_proc_impl.cc
@@ -22,7 +22,10 @@
 #endif
 
 #include <string.h>
+#include <boost/bind/bind.hpp>
 #include "vec_sink_c_proc_impl.h"
+
+using namespace boost::placeholders;
 
 namespace gr {
   namespace bokehgui {

--- a/lib/vec_sink_f_proc_impl.cc
+++ b/lib/vec_sink_f_proc_impl.cc
@@ -22,7 +22,10 @@
 #endif
 
 #include <string.h>
+#include <boost/bind/bind.hpp>
 #include "vec_sink_f_proc_impl.h"
+
+using namespace boost::placeholders;
 
 namespace gr {
   namespace bokehgui {

--- a/lib/waterfall_sink_c_proc_impl.cc
+++ b/lib/waterfall_sink_c_proc_impl.cc
@@ -22,7 +22,10 @@
 #endif
 
 #include <string.h>
+#include <boost/bind/bind.hpp>
 #include "waterfall_sink_c_proc_impl.h"
+
+using namespace boost::placeholders;
 
 namespace gr {
   namespace bokehgui {

--- a/lib/waterfall_sink_f_proc_impl.cc
+++ b/lib/waterfall_sink_f_proc_impl.cc
@@ -22,7 +22,10 @@
 #endif
 
 #include <string.h>
+#include <boost/bind/bind.hpp>
 #include "waterfall_sink_f_proc_impl.h"
+
+using namespace boost::placeholders;
 
 namespace gr {
   namespace bokehgui {


### PR DESCRIPTION
fixes compil issues (most likely with recent versions of gcc)