### PR TITLE
Remove boost

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -50,14 +50,11 @@ ExperimentalAutoDetectBinPacking: false
 ForEachMacros:
   - foreach
   - Q_FOREACH
-  - BOOST_FOREACH
 IncludeCategories:
   - Regex:           '^"(gnuradio)/'
     Priority:        1
   - Regex:           '^<(gnuradio)/'
     Priority:        2
-  - Regex:           '^<(boost)/'
-    Priority:        98
   - Regex:           '^<[a-z]*>$'
     Priority:        99
   - Regex:           '^".*"$'

--- a/include/bokehgui/base_sink.h
+++ b/include/bokehgui/base_sink.h
@@ -71,8 +71,7 @@ namespace gr {
         d_index = 0;
 
         message_port_register_in(pmt::mp("in"));
-        set_msg_handler(pmt::mp("in"),
-                        boost::bind(&base_sink<T>::handle_pdus, this, _1));
+        set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
         const int alignment_multiple = volk_get_alignment() / (sizeof(T)*d_vlen);
         set_alignment(std::max(1, alignment_multiple));

--- a/lib/freq_sink_c_proc_impl.cc
+++ b/lib/freq_sink_c_proc_impl.cc
@@ -69,8 +69,7 @@ namespace gr {
       d_tmpbuf = std::vector<float>(d_tmpbuflen+1, 0);
 
       message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
-                      boost::bind(&freq_sink_c_proc_impl::handle_set_freq, this, _1));
+      set_msg_handler(pmt::mp("freq"), [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
       buildwindow();
 

--- a/lib/freq_sink_f_proc_impl.cc
+++ b/lib/freq_sink_f_proc_impl.cc
@@ -64,8 +64,7 @@ namespace gr {
       d_tmpbuf = std::vector<float>(d_tmpbuflen+1, 0);
 
       message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
-                      boost::bind(&freq_sink_f_proc_impl::handle_set_freq, this, _1));
+      set_msg_handler(pmt::mp("freq"), [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
       buildwindow();
 
@@ -325,4 +324,3 @@ namespace gr {
     }
   } /* namespace bokehgui */
 } /* namespace gr */
-

--- a/lib/time_sink_c_proc_impl.cc
+++ b/lib/time_sink_c_proc_impl.cc
@@ -132,8 +132,9 @@ namespace gr {
       d_trigger_count = 0;
 
       if((d_trigger_delay < 0) || (d_trigger_delay >= d_size)) {
-        GR_LOG_WARN(d_logger, boost::format("Trigger delay (%1%) outside of display range (0:%2%).") \
-                    % (d_trigger_delay/d_samp_rate) % ((d_size - 1) / d_samp_rate));
+        GR_LOG_WARN(d_logger, "Trigger delay (" + std::to_string(d_trigger_delay/d_samp_rate) + ") outside of display range (0:" + std::to_string((d_size - 1) / d_samp_rate) + ").");
+        // GR_LOG_WARN(d_logger, boost::format("Trigger delay (%1%) outside of display range (0:%2%).") \
+        //             % (d_trigger_delay/d_samp_rate) % ((d_size - 1) / d_samp_rate));
         d_trigger_delay = std::max(0, std::min(d_size - 1, d_trigger_delay));
         delay = d_trigger_delay/d_samp_rate;
       }
@@ -155,8 +156,9 @@ namespace gr {
 
         // If delay was set beyond the new boundary, pull it back.
         if(d_trigger_delay >= d_size) {
-          GR_LOG_WARN(d_logger, boost::format("Trigger delay (%1%) outside of display range (0:%2:). Moving to 50%% point.") \
-                    % (d_trigger_delay/d_samp_rate) % ((d_size-1)/d_samp_rate));
+          GR_LOG_WARN(d_logger, "Trigger delay (" + std::to_string(d_trigger_delay/d_samp_rate) + ") outside of display range (0:" + std::to_string((d_size - 1) / d_samp_rate) + "). Moving to 50%% point.");
+          // GR_LOG_WARN(d_logger, boost::format("Trigger delay (%1%) outside of display range (0:%2:). Moving to 50%% point.") \
+          //           % (d_trigger_delay/d_samp_rate) % ((d_size-1)/d_samp_rate));
           d_trigger_delay = d_size - 1;
         }
         _reset();
@@ -267,4 +269,3 @@ namespace gr {
     }
   } /* namespace bokehgui */
 } /* namespace gr */
-

--- a/lib/time_sink_f_proc_impl.cc
+++ b/lib/time_sink_f_proc_impl.cc
@@ -138,8 +138,9 @@ namespace gr {
       d_trigger_count = 0;
 
       if((d_trigger_delay < 0) || (d_trigger_delay >= d_size)) {
-        GR_LOG_WARN(d_logger, boost::format("Trigger delay (%1%) outside of display range (0:%2%).") \
-                    % (d_trigger_delay/d_samp_rate) % ((d_size-1)/d_samp_rate));
+        GR_LOG_WARN(d_logger, "Trigger delay (" + std::to_string(d_trigger_delay/d_samp_rate) + ") outside of display range (0:" + std::to_string((d_size - 1) / d_samp_rate) + ").");
+        // GR_LOG_WARN(d_logger, boost::format("Trigger delay (%1%) outside of display range (0:%2%).") \
+        //             % (d_trigger_delay/d_samp_rate) % ((d_size - 1) / d_samp_rate));
         d_trigger_delay = std::max(0, std::min(d_size-1, d_trigger_delay));
         delay = d_trigger_delay/d_samp_rate;
       }
@@ -162,8 +163,9 @@ namespace gr {
 
         // If delay was set beyond the new boundary, pull it back.
         if(d_trigger_delay >= d_size) {
-          GR_LOG_WARN(d_logger, boost::format("Trigger delay (%1%) outside of display range (0:%2%). Moving to 50%% point.") \
-                      % (d_trigger_delay/d_samp_rate) % ((d_size-1)/d_samp_rate));
+          GR_LOG_WARN(d_logger, "Trigger delay (" + std::to_string(d_trigger_delay/d_samp_rate) + ") outside of display range (0:" + std::to_string((d_size - 1) / d_samp_rate) + "). Moving to 50%% point.");
+          // GR_LOG_WARN(d_logger, boost::format("Trigger delay (%1%) outside of display range (0:%2:). Moving to 50%% point.") \
+          //           % (d_trigger_delay/d_samp_rate) % ((d_size-1)/d_samp_rate));
           d_trigger_delay = d_size-1;
         }
         _reset();

--- a/lib/vec_sink_c_proc_impl.cc
+++ b/lib/vec_sink_c_proc_impl.cc
@@ -46,8 +46,7 @@ namespace gr {
     {
 
       // message_port_register_in(pmt::mp("freq"));
-      // set_msg_handler(pmt::mp("freq"),
-      //                 boost::bind(&vec_sink_f_proc_impl::handle_set_freq, this, _1));
+      // set_msg_handler(pmt::mp("freq"), [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
 
       d_trigger_mode = TRIG_MODE_FREE;

--- a/lib/vec_sink_f_proc_impl.cc
+++ b/lib/vec_sink_f_proc_impl.cc
@@ -46,8 +46,7 @@ namespace gr {
     {
 
       // message_port_register_in(pmt::mp("freq"));
-      // set_msg_handler(pmt::mp("freq"),
-      //                 boost::bind(&vec_sink_f_proc_impl::handle_set_freq, this, _1));
+      // set_msg_handler(pmt::mp("freq"), [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
 
       d_trigger_mode = TRIG_MODE_FREE;

--- a/lib/waterfall_sink_c_proc_impl.cc
+++ b/lib/waterfall_sink_c_proc_impl.cc
@@ -49,8 +49,7 @@ namespace gr {
       d_fbuf = std::vector<float> (d_size, 0);
 
       message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
-                      boost::bind(&waterfall_sink_c_proc_impl::handle_set_freq, this, _1));
+      set_msg_handler(pmt::mp("freq"), [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
       buildwindow();
 

--- a/lib/waterfall_sink_f_proc_impl.cc
+++ b/lib/waterfall_sink_f_proc_impl.cc
@@ -50,8 +50,7 @@ namespace gr {
       d_fbuf = std::vector<float> (d_size, 0);
 
       message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
-                      boost::bind(&waterfall_sink_f_proc_impl::handle_set_freq, this, _1));
+      set_msg_handler(pmt::mp("freq"), [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
       buildwindow();
 


### PR DESCRIPTION
Remove all the remaining uses of boost.

Namely boost::bind in the definition of message handler callbacks, replaced by a lambda expression.
And boost::format in the logging messages for the time sink, replaced by a crude string concatenation.
There was a new non-boost logging and formatting system introduced with gr 3.10, but that way, it should remain compatible between gr 3.9 and 3.10.