### PR TITLE
Plots: Switch from webgl to canvas rendering

### DIFF
--- a/python/const_sink_c.py
+++ b/python/const_sink_c.py
@@ -70,7 +70,7 @@ class const_sink_c(bokeh_plot_config):
         plot = figure(tools = tools, active_drag = 'pan',
                            active_scroll = 'wheel_zoom',
                            y_axis_type = 'linear', x_axis_type = 'linear',
-                           output_backend="webgl",
+                           output_backend="canvas",
                            title=self.name)
         data = dict()
 

--- a/python/freq_sink_c.py
+++ b/python/freq_sink_c.py
@@ -76,7 +76,7 @@ class freq_sink_c(bokeh_plot_config):
             tools=utils.default_tools(),
             active_drag="ypan",
             active_scroll="ywheel_zoom",
-            output_backend="webgl",
+            output_backend="canvas",
             title=self.name,
         )
         data = dict()

--- a/python/freq_sink_f.py
+++ b/python/freq_sink_f.py
@@ -76,7 +76,7 @@ class freq_sink_f(bokeh_plot_config):
             tools=utils.default_tools(),
             active_drag="ypan",
             active_scroll="ywheel_zoom",
-            output_backend="webgl",
+            output_backend="canvas",
             title=self.name,
         )
         data = dict()

--- a/python/time_sink_c.py
+++ b/python/time_sink_c.py
@@ -68,7 +68,7 @@ class time_sink_c(bokeh_plot_config):
                            active_scroll = 'ywheel_zoom',
                            y_axis_type = y_axis_type,
                            x_axis_type = x_axis_type,
-                           output_backend="webgl",
+                           output_backend="canvas",
                            title=self.name)
         data = dict()
         tag_data = dict()

--- a/python/time_sink_f.py
+++ b/python/time_sink_f.py
@@ -69,7 +69,7 @@ class time_sink_f(bokeh_plot_config):
                            active_scroll = 'ywheel_zoom',
                            y_axis_type = y_axis_type,
                            x_axis_type = x_axis_type,
-                           output_backend="webgl",
+                           output_backend="canvas",
                            title=self.name)
         data = dict()
         tag_data = dict()

--- a/python/vec_sink_c.py
+++ b/python/vec_sink_c.py
@@ -68,7 +68,7 @@ class vec_sink_c(bokeh_plot_config):
             tools=utils.default_tools(),
             active_drag="ypan",
             active_scroll="ywheel_zoom",
-            output_backend="webgl",
+            output_backend="canvas",
             title=self.name,
         )
         data = dict()

--- a/python/vec_sink_f.py
+++ b/python/vec_sink_f.py
@@ -68,7 +68,7 @@ class vec_sink_f(bokeh_plot_config):
             tools=utils.default_tools(),
             active_drag="ypan",
             active_scroll="ywheel_zoom",
-            output_backend="webgl",
+            output_backend="canvas",
             title=self.name,
         )
         data = dict()

--- a/python/waterfall_sink_c.py
+++ b/python/waterfall_sink_c.py
@@ -67,7 +67,7 @@ class waterfall_sink_c(bokeh_plot_config):
                            y_range = [0, self.nrows],
                            x_range = [self.frequency_range[0],
                                       self.frequency_range[-1]],
-                                      output_backend="webgl",
+                                      output_backend="canvas",
                                       title=self.name)
         plot.yaxis.formatter = CustomJSTickFormatter(code = """
                            return (%s - tick)*%s

--- a/python/waterfall_sink_f.py
+++ b/python/waterfall_sink_f.py
@@ -67,7 +67,7 @@ class waterfall_sink_f(bokeh_plot_config):
                            y_range = [0, self.nrows],
                            x_range = [self.frequency_range[0],
                                       self.frequency_range[-1]],
-                                      output_backend="webgl",
+                                      output_backend="canvas",
                                       title=self.name)
         # plot.yaxis.formatter = CustomJSTickFormatter(code = """
         #                    return (%s - tick)*%s


### PR DESCRIPTION
Change rendering backend of plots from WebGL to canvas.

This appears to increase rendering performance, and thus allow to increase update frequency.