### PR TITLE
Trigger feature

### DIFF
--- a/examples/test_bokehgui.grc
+++ b/examples/test_bokehgui.grc
@@ -97,6 +97,24 @@ blocks:
     coordinate: [864, 460.0]
     rotation: 0
     state: enabled
+- name: level_fft
+  id: variable_bokehgui_slider
+  parameters:
+    comment: ''
+    end: '20'
+    label: Trigger level FFT
+    start: '-80'
+    step: '1'
+    throttle: '1'
+    type: real
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1168, 460.0]
+    rotation: 0
+    state: enabled
 - name: noise_amp
   id: variable_bokehgui_slider
   parameters:
@@ -506,8 +524,8 @@ blocks:
     style8: '"solid"'
     style9: '"solid"'
     tr_chan: '0'
-    tr_level: '0.0'
-    tr_mode: bokehgui.TRIG_MODE_FREE
+    tr_level: level_fft
+    tr_mode: bokehgui.TRIG_MODE_NORM
     tr_tag: '""'
     type: complex
     update_time: int(1000*(1/up_freq))
@@ -604,8 +622,8 @@ blocks:
     style8: '"solid"'
     style9: '"solid"'
     tr_chan: '0'
-    tr_level: '0.0'
-    tr_mode: bokehgui.TRIG_MODE_FREE
+    tr_level: level_fft
+    tr_mode: bokehgui.TRIG_MODE_NORM
     tr_tag: '""'
     type: float
     update_time: int(1000*(1/up_freq))
@@ -699,8 +717,8 @@ blocks:
     style9: ''
     tr_chan: '0'
     tr_delay: '0'
-    tr_level: '0.0'
-    tr_mode: bokehgui.TRIG_MODE_FREE
+    tr_level: level
+    tr_mode: bokehgui.TRIG_MODE_NORM
     tr_slope: bokehgui.TRIG_SLOPE_POS
     tr_tag: '""'
     type: complex
@@ -896,7 +914,7 @@ blocks:
     tr_chan: '0'
     tr_delay: delay
     tr_level: level
-    tr_mode: bokehgui.TRIG_MODE_NORM
+    tr_mode: bokehgui.TRIG_MODE_AUTO
     tr_slope: bokehgui.TRIG_SLOPE_POS
     tr_tag: '""'
     type: float

--- a/examples/test_bokehgui.grc
+++ b/examples/test_bokehgui.grc
@@ -47,6 +47,24 @@ blocks:
     coordinate: [808, 4.0]
     rotation: 0
     state: enabled
+- name: delay
+  id: variable_bokehgui_slider
+  parameters:
+    comment: ''
+    end: '0.02'
+    label: Trigger delay
+    start: '0'
+    step: '0.0001'
+    throttle: '1'
+    type: real
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1024, 460.0]
+    rotation: 0
+    state: enabled
 - name: frequency
   id: variable_bokehgui_textbox
   parameters:
@@ -59,6 +77,24 @@ blocks:
     bus_source: false
     bus_structure: null
     coordinate: [392, 4.0]
+    rotation: 0
+    state: enabled
+- name: level
+  id: variable_bokehgui_slider
+  parameters:
+    comment: ''
+    end: '1'
+    label: Trigger level
+    start: '-1'
+    step: '0.01'
+    throttle: '1'
+    type: real
+    value: '0.05'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [864, 460.0]
     rotation: 0
     state: enabled
 - name: noise_amp
@@ -76,7 +112,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [200, 92.0]
+    coordinate: [224, 100.0]
     rotation: 0
     state: enabled
 - name: ntype_cmplx
@@ -120,7 +156,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1009, 10]
+    coordinate: [1408, 12.0]
     rotation: 0
     state: enabled
 - name: offset
@@ -138,14 +174,14 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [336, 108.0]
+    coordinate: [360, 100.0]
     rotation: 0
     state: true
 - name: samp_rate
   id: variable
   parameters:
     comment: ''
-    value: '5000'
+    value: '50000'
   states:
     bus_sink: false
     bus_source: false
@@ -163,7 +199,7 @@ blocks:
     step: '0.01'
     throttle: '10'
     type: real
-    value: '10.0'
+    value: '0.1'
   states:
     bus_sink: false
     bus_source: false
@@ -175,7 +211,7 @@ blocks:
   id: variable
   parameters:
     comment: "Update frequency \nof the Bokeh plots"
-    value: '1'
+    value: '5'
   states:
     bus_sink: false
     bus_source: false
@@ -231,9 +267,10 @@ blocks:
     freq: frequency
     maxoutbuf: '0'
     minoutbuf: '0'
-    offset: offset[0]
+    offset: offset[0] + 1j* offset[1]
     phase: '0'
     samp_rate: samp_rate
+    showports: 'False'
     type: complex
     waveform: analog.GR_COS_WAVE
   states:
@@ -256,6 +293,7 @@ blocks:
     offset: offset[1]
     phase: '0'
     samp_rate: samp_rate
+    showports: 'False'
     type: float
     waveform: analog.GR_COS_WAVE
   states:
@@ -280,7 +318,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [288, 232.0]
+    coordinate: [248, 224.0]
     rotation: 0
     state: enabled
 - name: blocks_add_xx_1
@@ -298,7 +336,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [288, 520.0]
+    coordinate: [248, 520.0]
     rotation: 0
     state: enabled
 - name: blocks_stream_to_vector_0
@@ -319,6 +357,48 @@ blocks:
     coordinate: [808, 168.0]
     rotation: 0
     state: enabled
+- name: blocks_throttle2_0
+  id: blocks_throttle2
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    limit: items
+    maximum: '0.1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [304, 332.0]
+    rotation: 0
+    state: enabled
+- name: blocks_throttle2_1
+  id: blocks_throttle2
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    limit: time
+    maximum: '0.1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [376, 644.0]
+    rotation: 0
+    state: enabled
 - name: blocks_throttle_0
   id: blocks_throttle
   parameters:
@@ -337,7 +417,7 @@ blocks:
     bus_structure: null
     coordinate: [384, 244.0]
     rotation: 0
-    state: enabled
+    state: disabled
 - name: blocks_throttle_1
   id: blocks_throttle
   parameters:
@@ -356,7 +436,7 @@ blocks:
     bus_structure: null
     coordinate: [384, 532.0]
     rotation: 0
-    state: enabled
+    state: disabled
 - name: bokehgui_frequency_sink_x_0
   id: bokehgui_frequency_sink_x
   parameters:
@@ -401,7 +481,7 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    marker1: None
+    marker1: '''+'''
     marker10: None
     marker2: None
     marker3: None
@@ -412,8 +492,6 @@ blocks:
     marker8: None
     marker9: None
     maxhold: 'True'
-    maxoutbuf: '0'
-    minoutbuf: '0'
     name: Complex Frequency Sink
     nconnections: '1'
     placement: (5,0,1,1)
@@ -501,7 +579,7 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    marker1: None
+    marker1: '''d'''
     marker10: None
     marker2: None
     marker3: None
@@ -512,8 +590,6 @@ blocks:
     marker8: None
     marker9: None
     maxhold: 'False'
-    maxoutbuf: '0'
-    minoutbuf: '0'
     name: Float Frequency Sink
     nconnections: '1'
     placement: (7,0,1,1)
@@ -597,16 +673,16 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    marker1: '''o'''
-    marker10: '''o'''
-    marker2: '''o'''
-    marker3: '''o'''
-    marker4: '''o'''
-    marker5: '''o'''
-    marker6: '''o'''
-    marker7: '''o'''
-    marker8: '''o'''
-    marker9: '''o'''
+    marker1: '''diamond_cross'''
+    marker10: '''circle'''
+    marker2: '''circle'''
+    marker3: '''circle'''
+    marker4: '''circle'''
+    marker5: '''circle'''
+    marker6: '''circle'''
+    marker7: '''circle'''
+    marker8: '''circle'''
+    marker9: '''circle'''
     name: '""'
     nconnections: '1'
     placement: (2,1,2,2)
@@ -640,12 +716,12 @@ blocks:
     width8: '1'
     width9: '1'
     xlabel: I Channel
-    xmax: '100'
-    xmin: '-100'
+    xmax: '10'
+    xmin: '-10'
     xunit: '""'
     ylabel: Q Channel
-    ymax: '100'
-    ymin: '-100'
+    ymax: '10'
+    ymin: '-10'
     yunit: '""'
   states:
     bus_sink: false
@@ -694,9 +770,9 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    marker1: None
+    marker1: '''circle'''
     marker10: None
-    marker2: None
+    marker2: '''square'''
     marker3: None
     marker4: None
     marker5: None
@@ -707,7 +783,7 @@ blocks:
     name: Complex Time Sink
     nconnections: '1'
     placement: (0,1,2,2)
-    size: '1000'
+    size: '687'
     srate: samp_rate
     style1: '"solid"'
     style10: '"solid"'
@@ -720,9 +796,9 @@ blocks:
     style8: '"solid"'
     style9: '"solid"'
     tr_chan: '0'
-    tr_delay: '0'
-    tr_level: '0.0'
-    tr_mode: bokehgui.TRIG_MODE_FREE
+    tr_delay: delay
+    tr_level: level
+    tr_mode: bokehgui.TRIG_MODE_NORM
     tr_slope: bokehgui.TRIG_SLOPE_POS
     tr_tag: '""'
     type: complex
@@ -749,7 +825,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [576, 340.0]
+    coordinate: [576, 364.0]
     rotation: 0
     state: enabled
 - name: bokehgui_time_sink_x_1
@@ -781,7 +857,7 @@ blocks:
     comment: ''
     entags: 'True'
     grid: 'False'
-    label1: ''
+    label1: elo
     label10: ''
     label2: ''
     label3: ''
@@ -792,7 +868,7 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    marker1: None
+    marker1: '''square_x'''
     marker10: None
     marker2: None
     marker3: None
@@ -818,9 +894,9 @@ blocks:
     style8: '"solid"'
     style9: '"solid"'
     tr_chan: '0'
-    tr_delay: '0'
-    tr_level: '0.0'
-    tr_mode: bokehgui.TRIG_MODE_FREE
+    tr_delay: delay
+    tr_level: level
+    tr_mode: bokehgui.TRIG_MODE_NORM
     tr_slope: bokehgui.TRIG_SLOPE_POS
     tr_tag: '""'
     type: float
@@ -847,7 +923,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [576, 628.0]
+    coordinate: [576, 644.0]
     rotation: 0
     state: enabled
 - name: bokehgui_vector_sink_x_0
@@ -901,8 +977,6 @@ blocks:
     marker8: None
     marker9: None
     maxhold: 'True'
-    maxoutbuf: '0'
-    minoutbuf: '0'
     name: '"Float vector"'
     nconnections: '1'
     placement: (2,3,2,2)
@@ -994,8 +1068,6 @@ blocks:
     marker8: None
     marker9: None
     maxhold: 'True'
-    maxoutbuf: '0'
-    minoutbuf: '0'
     name: '"Complex vector sink"'
     nconnections: '1'
     placement: (0,3,2,2)
@@ -1051,8 +1123,6 @@ blocks:
     int_min: '-140'
     label: ''
     legend: 'True'
-    maxoutbuf: '0'
-    minoutbuf: '0'
     name: '"Complex waterfall"'
     placement: (8,0,1,1)
     type: complex
@@ -1084,9 +1154,7 @@ blocks:
     int_min: '-140'
     label: ''
     legend: 'True'
-    maxoutbuf: '0'
-    minoutbuf: '0'
-    name: '""'
+    name: '"Float Waterfall"'
     placement: (9,0,1,1)
     type: float
     update_time: int(1000*(1/up_freq))
@@ -1099,7 +1167,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [576, 556.0]
+    coordinate: [576, 548.0]
     rotation: 0
     state: enabled
 - name: fft_vxx_0
@@ -1152,9 +1220,19 @@ connections:
 - [analog_noise_source_x_1, '0', blocks_add_xx_1, '1']
 - [analog_sig_source_x_0, '0', blocks_add_xx_0, '0']
 - [analog_sig_source_x_1, '0', blocks_add_xx_1, '0']
+- [blocks_add_xx_0, '0', blocks_throttle2_0, '0']
 - [blocks_add_xx_0, '0', blocks_throttle_0, '0']
+- [blocks_add_xx_1, '0', blocks_throttle2_1, '0']
 - [blocks_add_xx_1, '0', blocks_throttle_1, '0']
 - [blocks_stream_to_vector_0, '0', fft_vxx_0, '0']
+- [blocks_throttle2_0, '0', blocks_stream_to_vector_0, '0']
+- [blocks_throttle2_0, '0', bokehgui_frequency_sink_x_0, '0']
+- [blocks_throttle2_0, '0', bokehgui_time_const_x_0, '0']
+- [blocks_throttle2_0, '0', bokehgui_time_sink_x_0, '0']
+- [blocks_throttle2_0, '0', bokehgui_waterfall_sink_x_0, '0']
+- [blocks_throttle2_0, '0', logpwrfft_x_0, '0']
+- [blocks_throttle2_1, '0', bokehgui_frequency_sink_x_1, '0']
+- [blocks_throttle2_1, '0', bokehgui_time_sink_x_1, '0']
 - [blocks_throttle_0, '0', blocks_stream_to_vector_0, '0']
 - [blocks_throttle_0, '0', bokehgui_frequency_sink_x_0, '0']
 - [blocks_throttle_0, '0', bokehgui_time_const_x_0, '0']
@@ -1169,3 +1247,4 @@ connections:
 
 metadata:
   file_format: 1
+  grc_version: 3.10.9.2

--- a/include/bokehgui/freq_sink_c_proc.h
+++ b/include/bokehgui/freq_sink_c_proc.h
@@ -75,6 +75,9 @@ namespace gr {
       static sptr make(int fftsize, int wintype, double fc, double bw, const std::string &name, int nconnections);
 
       virtual void reset() = 0;
+      virtual float * get_plot_data() = 0;
+      virtual int get_buff_size() = 0;
+      virtual int get_buff_cols() = 0;
 
       virtual double get_center_freq() = 0;
       virtual double get_bandwidth() = 0;

--- a/lib/freq_sink_c_proc_impl.cc
+++ b/lib/freq_sink_c_proc_impl.cc
@@ -87,6 +87,10 @@ namespace gr {
 
       d_fbuf = std::vector<float> ();
       d_tmpbuf = std::vector<float> ();
+
+
+      while(!d_buffer_queue.empty())
+        d_buffer_queue.pop();
     }
 
     void
@@ -107,13 +111,49 @@ namespace gr {
       _reset();
     }
 
+    float * freq_sink_c_proc_impl::get_plot_data () {
+        gr::thread::scoped_lock lock(d_setlock);
+        if (!d_buffer_queue.size()) {
+          int size = 0;
+          int nrows = d_nconnections + 1;
+          float* arr = (float*) malloc(2*(nrows)*(size)*sizeof(float));
+          return arr;
+        }
+
+        int nrows = d_nconnections + 1;  //Why the +1? why not d_buffer_queue.front().size()?
+        int size = d_buffer_queue.front()[0].size();
+
+        float* arr = (float*) malloc((nrows)*(size)*sizeof(float)); // Why the 2* and the size float and not T?
+        memset(arr, 0, (nrows)*(size)*sizeof(float));
+        process_plot(arr, &nrows, &size);
+
+        d_buffer_queue.pop();
+
+        return arr;
+      }
+
+    int freq_sink_c_proc_impl::get_buff_size(){
+      if (!d_buffer_queue.size()) {
+        // printf("The buffer is empty, returning 0\n");
+        return 0;
+      }
+      return d_buffer_queue.front()[0].size();
+    }
+
+    int freq_sink_c_proc_impl::get_buff_num_items(){
+      return d_buffer_queue.size();
+    }
+
+    int freq_sink_c_proc_impl::get_buff_cols(){
+      return d_nconnections;
+    }
+
     void
     freq_sink_c_proc_impl::process_plot(float* arr, int* nrows, int* size) {
       if(d_nconnections != 0) {
         for(int n = 0; n < (*nrows - 1); n++) {
-          fft(&d_fbuf[0], &d_buffers.front()[n][0], *size);
           for(int x = 0; x < *size; x++) {
-            arr[n*(*size) + x] = d_fbuf[x];
+            arr[n*(*size) + x] = d_buffer_queue.front()[n][x];
           }
         }
       }
@@ -130,7 +170,7 @@ namespace gr {
           // Clear in case (max-min) < d_size
           memset(&temp_zero_vec[0], 0, d_size*sizeof(gr_complex));
           // Copy as much possible samples as we can
-          memcpy(&temp_zero_vec[0], &d_buffers.front()[0][min], (max-min)*sizeof(gr_complex));
+          memcpy(&temp_zero_vec[0], &d_buffer_queue.front()[0][min], (max-min)*sizeof(gr_complex));
           // Apply the window and FFT; copy data into the PDU magnitude buffer
           fft(&d_fbuf[0], &temp_zero_vec[0], d_size);
           for(int x = 0; x < d_size; x++) {
@@ -271,32 +311,84 @@ namespace gr {
       d_triggered = true;
     }
 
-    // void
-    // freq_sink_c_proc_impl::_test_trigger_norm(int nitems, std::vector<std::vector<float> > inputs)
-    // {
-    //   const float *in = &inputs[d_trigger_channel][0];
-    //   for(int i = 0; i < nitems; i++) {
-    //     d_trigger_count++;
+    void
+    freq_sink_c_proc_impl::_test_trigger_norm(int nitems, std::vector<std::vector<float> > inputs)
+    {
+      const float *in = &inputs[d_trigger_channel][0];
+      for(int i = 0; i < nitems; i++) {
+        d_trigger_count++; // Might want to adjust how this count is handled. Currently would trigger everytime
 
-    //     // Test if trigger has occurred based on the FFT magnitude and
-    //     // channel number. Test if any value is > the level in dBx
-    //     if(in[i] > d_trigger_level) {
-    //       d_triggered = true;
-    //       d_trigger_count = 0;
-    //       break;
-    //     }
-    //   }
+        // Test if trigger has occurred based on the FFT magnitude and
+        // channel number. Test if any value is > the level in dBx
+        if(in[i] > d_trigger_level) {
+          d_triggered = true;
+          d_trigger_count = 0;
+          break;
+        }
+      }
 
-    //   // If using auto trigger mode, trigger periodically even
-    //   // without a trigger event
-    //   if((d_trigger_mode == TRIG_MODE_AUTO) && (d_trigger_count > d_size)) {
-    //     d_triggered = true;
-    //     d_trigger_count = 0;
-    //   }
-    // }
 
+      // If using auto trigger mode, trigger periodically even
+      // without a trigger event
+      if((d_trigger_mode == TRIG_MODE_AUTO) && (d_trigger_count > d_size*30)) {
+        d_triggered = true;
+        d_trigger_count = 0;
+      }
+    }
+
+    int freq_sink_c_proc_impl::work(int noutput_items,
+            gr_vector_const_void_star &input_items,
+            gr_vector_void_star &output_items) {
+      gr::thread::scoped_lock lock(d_setlock);
+
+      // Consume all possible set of data. Each with d_size
+      for(d_index = 0; d_index < noutput_items-d_size;) {
+
+        // We always neet to compute the FFT here to allow triggering
+        std::vector<std::vector<float>> data_buff(d_nconnections, std::vector<float>(d_size));
+        for(int n = 0; n < d_nconnections; n++){
+          fft(&data_buff[n][0], &((const gr_complex*)input_items[n])[d_index], d_size);
+        }
+
+        // Include auto/normal triggers
+        if(d_trigger_mode == TRIG_MODE_TAG) {
+          _test_trigger_tags(d_index, d_size);
+        }
+        // Else normal trigger
+        else if (d_trigger_mode != TRIG_MODE_FREE)
+        {
+          _test_trigger_norm(d_size, data_buff);
+        }
+
+        // The d_triggered and d_index is set.
+        // We will now check if triggered.
+        // If it is triggered then we check the trigger_index = d_index
+        // We will start looking from d_index to the end of input_items
+        // First check if d_index+d_size < noutput_items
+        if(d_triggered) {
+          if(d_buffer_queue.size() == d_queue_size) {  //Make room if buffer queue is full
+            d_buffer_queue.pop();
+            pop_other_queues();
+          }
+
+          d_buffer_queue.push(data_buff);
+          work_process_other_queues(d_index, d_size);
+          if(d_trigger_mode != TRIG_MODE_FREE)
+            d_triggered = false;
+        }
+        d_index += d_size;
+      }
+      return d_index;
+    }
+    
     void
     freq_sink_c_proc_impl::pop_other_queues() {}
+
+
+    void freq_sink_c_proc_impl::clear_queue() {
+        while(!d_buffer_queue.empty())
+          d_buffer_queue.pop();
+    }
 
     void
     freq_sink_c_proc_impl::verify_datatype_PDU(const gr_complex* in, pmt::pmt_t samples, size_t len) {

--- a/lib/freq_sink_c_proc_impl.cc
+++ b/lib/freq_sink_c_proc_impl.cc
@@ -266,28 +266,34 @@ namespace gr {
     }
 
     void
-    freq_sink_c_proc_impl::_test_trigger_norm(int nitems, std::vector<std::vector<float> > inputs)
+    freq_sink_c_proc_impl::_test_trigger_norm(int start, int nitems, gr_vector_const_void_star inputs)
     {
-      const float *in = &inputs[d_trigger_channel][0];
-      for(int i = 0; i < nitems; i++) {
-        d_trigger_count++;
-
-        // Test if trigger has occurred based on the FFT magnitude and
-        // channel number. Test if any value is > the level in dBx
-        if(in[i] > d_trigger_level) {
-          d_triggered = true;
-          d_trigger_count = 0;
-          break;
-        }
-      }
-
-      // If using auto trigger mode, trigger periodically even
-      // without a trigger event
-      if((d_trigger_mode == TRIG_MODE_AUTO) && (d_trigger_count > d_size)) {
-        d_triggered = true;
-        d_trigger_count = 0;
-      }
+      d_triggered = true;
     }
+
+    // void
+    // freq_sink_c_proc_impl::_test_trigger_norm(int nitems, std::vector<std::vector<float> > inputs)
+    // {
+    //   const float *in = &inputs[d_trigger_channel][0];
+    //   for(int i = 0; i < nitems; i++) {
+    //     d_trigger_count++;
+
+    //     // Test if trigger has occurred based on the FFT magnitude and
+    //     // channel number. Test if any value is > the level in dBx
+    //     if(in[i] > d_trigger_level) {
+    //       d_triggered = true;
+    //       d_trigger_count = 0;
+    //       break;
+    //     }
+    //   }
+
+    //   // If using auto trigger mode, trigger periodically even
+    //   // without a trigger event
+    //   if((d_trigger_mode == TRIG_MODE_AUTO) && (d_trigger_count > d_size)) {
+    //     d_triggered = true;
+    //     d_trigger_count = 0;
+    //   }
+    // }
 
     void
     freq_sink_c_proc_impl::pop_other_queues() {}

--- a/lib/freq_sink_c_proc_impl.h
+++ b/lib/freq_sink_c_proc_impl.h
@@ -38,6 +38,8 @@ namespace gr {
        unsigned int d_tmpbuflen;
        std::vector<float> d_tmpbuf;
 
+       std::queue<std::vector<std::vector<float> > > d_buffer_queue;
+
        // Some freq_sink specific trigger
        float d_trigger_level;
        int d_trigger_count;
@@ -46,6 +48,9 @@ namespace gr {
       freq_sink_c_proc_impl(int fftsize, int wintype, double fc, double bw, const std::string &name, int nconnections);
       ~freq_sink_c_proc_impl();
 
+      int work(int noutput_items,
+            gr_vector_const_void_star &input_items,
+            gr_vector_void_star &output_items);
       void set_trigger_mode(trigger_mode mode,
                             float level,
                             int channel,
@@ -60,15 +65,20 @@ namespace gr {
       void handle_set_freq(pmt::pmt_t);
       void _test_trigger_tags(int, int);
       void _test_trigger_norm(int, int, gr_vector_const_void_star);
-      // void _test_trigger_norm(int, std::vector<std::vector<float> >);  Not supported Currently. TODO: Support proper triggering here
+      void _test_trigger_norm(int, std::vector<std::vector<float> >); // Not supported Currently. TODO: Support proper triggering here
 
       double get_center_freq();
       double get_bandwidth();
       int get_wintype();
+      int get_buff_cols();
+      int get_buff_num_items();
+      int get_buff_size();
 
       // Virtual functions inherited from base_sink
+      float * get_plot_data();
       void process_plot(float* arr, int* nrows, int* size);
       void pop_other_queues();
+      void clear_queue();
       void verify_datatype_PDU(const gr_complex*, pmt::pmt_t, size_t);
       void work_process_other_queues(int start, int nitems);
     };

--- a/lib/freq_sink_c_proc_impl.h
+++ b/lib/freq_sink_c_proc_impl.h
@@ -59,7 +59,8 @@ namespace gr {
       void set_size(int newsize);
       void handle_set_freq(pmt::pmt_t);
       void _test_trigger_tags(int, int);
-      void _test_trigger_norm(int, std::vector<std::vector<float> >);
+      void _test_trigger_norm(int, int, gr_vector_const_void_star);
+      // void _test_trigger_norm(int, std::vector<std::vector<float> >);  Not supported Currently. TODO: Support proper triggering here
 
       double get_center_freq();
       double get_bandwidth();

--- a/lib/freq_sink_f_proc_impl.cc
+++ b/lib/freq_sink_f_proc_impl.cc
@@ -263,28 +263,34 @@ namespace gr {
     }
 
     void
-    freq_sink_f_proc_impl::_test_trigger_norm(int nitems, std::vector<std::vector<float> > inputs)
+    freq_sink_f_proc_impl::_test_trigger_norm(int start, int nitems, gr_vector_const_void_star inputs)
     {
-      const float *in = &inputs[d_trigger_channel][0];
-      for(int i = 0; i < nitems; i++) {
-        d_trigger_count++;
-
-        // Test if trigger has occurred based on the FFT magnitude and
-        // channel number. Test if any value is > the level in dBx
-        if(in[i] > d_trigger_level) {
-          d_triggered = true;
-          d_trigger_count = 0;
-          break;
-        }
-      }
-
-      // If using auto trigger mode, trigger peridically even
-      // without a trigger event
-      if((d_trigger_mode == TRIG_MODE_AUTO) && (d_trigger_count > d_size)) {
-        d_triggered = true;
-        d_trigger_count = 0;
-      }
+      d_triggered = true;
     }
+
+    // void
+    // freq_sink_f_proc_impl::_test_trigger_norm(int nitems, std::vector<std::vector<float> > inputs)
+    // {
+    //   const float *in = &inputs[d_trigger_channel][0];
+    //   for(int i = 0; i < nitems; i++) {
+    //     d_trigger_count++;
+
+    //     // Test if trigger has occurred based on the FFT magnitude and
+    //     // channel number. Test if any value is > the level in dBx
+    //     if(in[i] > d_trigger_level) {
+    //       d_triggered = true;
+    //       d_trigger_count = 0;
+    //       break;
+    //     }
+    //   }
+
+    //   // If using auto trigger mode, trigger peridically even
+    //   // without a trigger event
+    //   if((d_trigger_mode == TRIG_MODE_AUTO) && (d_trigger_count > d_size)) {
+    //     d_triggered = true;
+    //     d_trigger_count = 0;
+    //   }
+    // }
 
     void
     freq_sink_f_proc_impl::pop_other_queues() {

--- a/lib/freq_sink_f_proc_impl.h
+++ b/lib/freq_sink_f_proc_impl.h
@@ -63,7 +63,8 @@ namespace gr {
       void set_size(int newsize);
       void handle_set_freq(pmt::pmt_t);
       void _test_trigger_tags(int, int);
-      void _test_trigger_norm(int, std::vector<std::vector<float> >);
+      void _test_trigger_norm(int, int, gr_vector_const_void_star);
+      // void _test_trigger_norm(int, std::vector<std::vector<float> >);  Not supported Currently. TODO: Support proper triggering here
 
       double get_center_freq();
       double get_bandwidth();

--- a/lib/freq_sink_f_proc_impl.h
+++ b/lib/freq_sink_f_proc_impl.h
@@ -50,6 +50,9 @@ namespace gr {
                             int nconnections);
       ~freq_sink_f_proc_impl();
 
+      int work(int noutput_items,
+            gr_vector_const_void_star &input_items,
+            gr_vector_void_star &output_items);
       void set_trigger_mode(trigger_mode mode,
                             float level,
                             int channel,
@@ -64,7 +67,7 @@ namespace gr {
       void handle_set_freq(pmt::pmt_t);
       void _test_trigger_tags(int, int);
       void _test_trigger_norm(int, int, gr_vector_const_void_star);
-      // void _test_trigger_norm(int, std::vector<std::vector<float> >);  Not supported Currently. TODO: Support proper triggering here
+      void _test_trigger_norm(int, std::vector<std::vector<float> >); // Not supported Currently. TODO: Support proper triggering here
 
       double get_center_freq();
       double get_bandwidth();

--- a/lib/time_sink_c_proc_impl.cc
+++ b/lib/time_sink_c_proc_impl.cc
@@ -220,6 +220,7 @@ namespace gr {
     time_sink_c_proc_impl::_test_trigger_norm(int start, int nitems, gr_vector_const_void_star inputs)
     {
       int trigger_index;
+      start = std::max(start, d_trigger_delay);
       const gr_complex *cBuff = (const gr_complex*) inputs[d_trigger_channel];
       for(trigger_index = start; trigger_index < start + nitems; trigger_index++) {
         d_trigger_count++;
@@ -228,8 +229,13 @@ namespace gr {
         // channel number, and slope direction
         if(_test_trigger_slope(&cBuff[trigger_index])) {
           d_triggered = true;
-          d_index = trigger_index;
+          d_index = trigger_index - d_trigger_delay;
           d_trigger_count = 0;
+          if (d_index < 0)
+          {
+            d_logger->warn("Trigger asked for a negative delay: {} - {} = {}", trigger_index, d_trigger_delay, d_index);
+            d_index = 0;
+          }
           break;
         }
       }

--- a/lib/time_sink_f_proc_impl.cc
+++ b/lib/time_sink_f_proc_impl.cc
@@ -221,6 +221,7 @@ namespace gr {
     time_sink_f_proc_impl::_test_trigger_norm(int start, int nitems, gr_vector_const_void_star inputs)
     {
       int trigger_index;
+      start = std::max(start, d_trigger_delay);
       const float *in = (const float*)inputs[d_trigger_channel];
       for(trigger_index = start;
           trigger_index < nitems + start;
@@ -231,8 +232,13 @@ namespace gr {
         // channel number, and slope direction
         if(_test_trigger_slope(&in[trigger_index])) {
           d_triggered = true;
-          d_index = trigger_index;
+          d_index = trigger_index - d_trigger_delay;
           d_trigger_count = 0;
+          if (d_index < 0)
+          {
+            d_logger->warn("Trigger asked for a negative delay: {} - {} = {}", trigger_index, d_trigger_delay, d_index);
+            d_index = 0;
+          }
           break;
         }
       }
@@ -243,6 +249,8 @@ namespace gr {
         d_triggered = true;
         d_trigger_count = 0;
       }
+
+      // d_logger->warn("d_index is now {}", d_index);
     }
 
     void

--- a/lib/vec_sink_c_proc_impl.cc
+++ b/lib/vec_sink_c_proc_impl.cc
@@ -120,5 +120,11 @@ namespace gr {
 
     }
 
+    void
+    vec_sink_c_proc_impl::_test_trigger_norm(int start, int nitems, gr_vector_const_void_star inputs)
+    {
+      d_triggered = true;
+    }
+
   } /* namespace bokehgui */
 } /* namespace gr */

--- a/lib/vec_sink_c_proc_impl.h
+++ b/lib/vec_sink_c_proc_impl.h
@@ -49,6 +49,7 @@ namespace gr {
       void work_process_other_queues(int start, int nitems);
 
       void _test_trigger_tags(int, int);
+      void _test_trigger_norm(int, int, gr_vector_const_void_star); // TODO: Support proper triggering here
       void set_size(const int newsize);
 
     };

--- a/lib/vec_sink_f_proc_impl.cc
+++ b/lib/vec_sink_f_proc_impl.cc
@@ -118,5 +118,11 @@ namespace gr {
 
     }
 
+    void
+    vec_sink_f_proc_impl::_test_trigger_norm(int start, int nitems, gr_vector_const_void_star inputs)
+    {
+      d_triggered = true;
+    }
+
   } /* namespace bokehgui */
 } /* namespace gr */

--- a/lib/vec_sink_f_proc_impl.h
+++ b/lib/vec_sink_f_proc_impl.h
@@ -49,6 +49,7 @@ namespace gr {
       void work_process_other_queues(int start, int nitems);
 
       void _test_trigger_tags(int, int);
+      void _test_trigger_norm(int, int, gr_vector_const_void_star); // TODO: Support proper triggering here
       void set_size(const int newsize);
 
     };

--- a/lib/waterfall_sink_c_proc_impl.cc
+++ b/lib/waterfall_sink_c_proc_impl.cc
@@ -244,6 +244,12 @@ namespace gr {
     waterfall_sink_c_proc_impl::_test_trigger_tags(int start, int nitems)
     {
       d_triggered = true;
+    }    
+
+    void
+    waterfall_sink_c_proc_impl::_test_trigger_norm(int start, int nitems, gr_vector_const_void_star inputs)
+    {
+      d_triggered = true;
     }
 
     void

--- a/lib/waterfall_sink_c_proc_impl.h
+++ b/lib/waterfall_sink_c_proc_impl.h
@@ -54,6 +54,7 @@ namespace gr {
 
       void set_frequency_range(double, double);
       void _test_trigger_tags(int, int);
+      void _test_trigger_norm(int, int, gr_vector_const_void_star);
       double get_center_freq();
       double get_bandwidth();
       double get_time_per_fft();

--- a/lib/waterfall_sink_f_proc_impl.cc
+++ b/lib/waterfall_sink_f_proc_impl.cc
@@ -251,6 +251,12 @@ namespace gr {
     }
 
     void
+    waterfall_sink_f_proc_impl::_test_trigger_norm(int start, int nitems, gr_vector_const_void_star inputs)
+    {
+      d_triggered = true;
+    }
+
+    void
     waterfall_sink_f_proc_impl::pop_other_queues() {
     }
 

--- a/lib/waterfall_sink_f_proc_impl.h
+++ b/lib/waterfall_sink_f_proc_impl.h
@@ -57,6 +57,7 @@ namespace gr {
 
       void set_frequency_range(double, double);
       void _test_trigger_tags(int, int);
+      void _test_trigger_norm(int, int, gr_vector_const_void_star);
       double get_center_freq();
       double get_bandwidth();
       double get_time_per_fft();

--- a/python/bindings/freq_sink_c_proc_python.cc
+++ b/python/bindings/freq_sink_c_proc_python.cc
@@ -20,6 +20,7 @@
 #include <pybind11/complex.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/numpy.h>
 
 namespace py = pybind11;
 
@@ -48,6 +49,13 @@ void bind_freq_sink_c_proc(py::module& m)
         
 
 
+        .def("get_plot_data", [](freq_sink_c_proc &m){
+          int buff_size = m.get_buff_size();
+          return py::array_t<float>(
+            {m.get_buff_cols(), buff_size}, // shape
+            m.get_plot_data() // the data pointer
+          );
+        })
 
 
         

--- a/python/freq_sink_c.py
+++ b/python/freq_sink_c.py
@@ -16,7 +16,7 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
-from bokeh.models import ColumnDataSource, CustomJS
+from bokeh.models import ColumnDataSource, CustomJS, CustomAction
 from bokeh.plotting import figure
 from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
@@ -172,6 +172,24 @@ class freq_sink_c(bokeh_plot_config):
         )
         stream.js_on_change("streaming", callback_js)
         self.max_hold_plot.visible = self.max_hold
+
+        reset_action = CustomAction(
+            # icon=r"/path/to/icon.png", # TODO: Put some actual icon, and understand how to specify the path
+            callback = CustomJS(
+                args=dict(max_hold_source=max_hold_source),
+                code='''
+                    var max_data = max_hold_source.data;
+                    var no_of_elem = max_hold_source.data.y.length;
+
+                    for (let i = 0; i < no_of_elem; i++) {
+                        max_data['y'][i] = -Infinity
+                    }
+                    max_hold_source.change.emit();
+                '''
+            ),
+            description='Reset Max'
+        )
+        plot.add_tools(reset_action)
         # max-hold plot done
 
         plot_lst.append(self)

--- a/python/freq_sink_f.py
+++ b/python/freq_sink_f.py
@@ -16,7 +16,7 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
-from bokeh.models import ColumnDataSource, CustomJS
+from bokeh.models import ColumnDataSource, CustomJS, CustomAction
 from bokeh.plotting import figure
 from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
@@ -171,6 +171,24 @@ class freq_sink_f(bokeh_plot_config):
         )
         stream.js_on_change("streaming", callback_js)
         self.max_hold_plot.visible = self.max_hold
+
+        reset_action = CustomAction(
+            # icon=r"/path/to/icon.png", # TODO: Put some actual icon, and understand how to specify the path
+            callback = CustomJS(
+                args=dict(max_hold_source=max_hold_source),
+                code='''
+                    var max_data = max_hold_source.data;
+                    var no_of_elem = max_hold_source.data.y.length;
+
+                    for (let i = 0; i < no_of_elem; i++) {
+                        max_data['y'][i] = -Infinity
+                    }
+                    max_hold_source.change.emit();
+                '''
+            ),
+            description='Reset Max'
+        )
+        plot.add_tools(reset_action)
         # max-hold plot done
 
         plot_lst.append(self)

--- a/python/vec_sink_c.py
+++ b/python/vec_sink_c.py
@@ -16,7 +16,7 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
-from bokeh.models import ColumnDataSource, CustomJS
+from bokeh.models import ColumnDataSource, CustomJS, CustomAction
 from bokeh.plotting import figure
 from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
@@ -164,6 +164,24 @@ class vec_sink_c(bokeh_plot_config):
         )
         stream.js_on_change("streaming", callback_js)
         self.max_hold_plot.visible = self.max_hold
+
+        reset_action = CustomAction(
+            # icon=r"/path/to/icon.png", # TODO: Put some actual icon, and understand how to specify the path
+            callback = CustomJS(
+                args=dict(max_hold_source=max_hold_source),
+                code='''
+                    var max_data = max_hold_source.data;
+                    var no_of_elem = max_hold_source.data.y.length;
+
+                    for (let i = 0; i < no_of_elem; i++) {
+                        max_data['y'][i] = -Infinity
+                    }
+                    max_hold_source.change.emit();
+                '''
+            ),
+            description='Reset Max'
+        )
+        plot.add_tools(reset_action)
         # max-hold plot done
 
         plot_lst.append(self)

--- a/python/vec_sink_f.py
+++ b/python/vec_sink_f.py
@@ -16,7 +16,7 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
-from bokeh.models import ColumnDataSource, CustomJS
+from bokeh.models import ColumnDataSource, CustomJS, CustomAction
 from bokeh.plotting import figure
 from bokeh.models.ranges import Range1d
 from bokehgui import bokeh_plot_config, utils
@@ -163,6 +163,24 @@ class vec_sink_f(bokeh_plot_config):
         )
         stream.js_on_change("streaming", callback_js)
         self.max_hold_plot.visible = self.max_hold
+
+        reset_action = CustomAction(
+            # icon=r"/path/to/icon.png", # TODO: Put some actual icon, and understand how to specify the path
+            callback = CustomJS(
+                args=dict(max_hold_source=max_hold_source),
+                code='''
+                    var max_data = max_hold_source.data;
+                    var no_of_elem = max_hold_source.data.y.length;
+
+                    for (let i = 0; i < no_of_elem; i++) {
+                        max_data['y'][i] = -Infinity
+                    }
+                    max_hold_source.change.emit();
+                '''
+            ),
+            description='Reset Max'
+        )
+        plot.add_tools(reset_action)
         # max-hold plot done
 
         plot_lst.append(self)


### PR DESCRIPTION
This PR adds a long missing feature to the Time, Frequency, and Constellation plots:
Triggering.

The parameters for it were already in place, but did not do anything.
Contrary to the QT displays, the trigger controls (Mode, Level and Delay) are not directly interactive in the plots themselves (I have not found a way to make Python callback from the Plot Tools).
So one needs to set the values before running the flowgraph, and for interactivity, level and delay are runtime modifiable, so one can add e.g. sliders to play with the value while running.
The test_bokehgui.grc flowgraph makes use of that.

Still standing issues or untested things:
* I have not tested operation with message inputs
* I have not tested operation with tags
* The Auto trigger mode is designed to trigger regularly when no triggering element is found. That triggering frequency could be tuned, or made available as a parameter.

As a bonus, adds a Tool to reset Max curves in Frequency and Vector sinks.
