### PR TITLE
Freq sink: update bindings hash

### DIFF
--- a/python/bindings/freq_sink_c_proc_python.cc
+++ b/python/bindings/freq_sink_c_proc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(freq_sink_c_proc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2c856903adac6c039877cacfc240e1e7)                     */
+/* BINDTOOL_HEADER_FILE_HASH(cbc59519a8072f288996ad16bf7f8a2b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Oops

I had forgotten to update the pybind11 file with the new hash.