### PR TITLE
Add scoped lock to get_buff_size functions

### DIFF
--- a/include/gnuradio/bokehgui/base_sink.h
+++ b/include/gnuradio/bokehgui/base_sink.h
@@ -122,6 +122,7 @@ namespace gr {
       }
 
       int get_buff_size(){
+        gr::thread::scoped_lock lock(d_setlock);
         if (!d_buffers.size()) {
           // printf("The buffer is empty, returning 0\n");
           return 0;

--- a/lib/freq_sink_c_proc_impl.cc
+++ b/lib/freq_sink_c_proc_impl.cc
@@ -133,6 +133,7 @@ namespace gr {
       }
 
     int freq_sink_c_proc_impl::get_buff_size(){
+      gr::thread::scoped_lock lock(d_setlock);
       if (!d_buffer_queue.size()) {
         // printf("The buffer is empty, returning 0\n");
         return 0;
@@ -141,6 +142,8 @@ namespace gr {
     }
 
     int freq_sink_c_proc_impl::get_buff_num_items(){
+
+      gr::thread::scoped_lock lock(d_setlock);
       return d_buffer_queue.size();
     }
 

--- a/lib/waterfall_sink_c_proc_impl.cc
+++ b/lib/waterfall_sink_c_proc_impl.cc
@@ -96,6 +96,7 @@ namespace gr {
     }
 
     int waterfall_sink_c_proc_impl::get_buff_size(){
+      gr::thread::scoped_lock lock(d_setlock);
       return d_buffers.front()[0].size();
     }
 

--- a/lib/waterfall_sink_f_proc_impl.cc
+++ b/lib/waterfall_sink_f_proc_impl.cc
@@ -97,6 +97,7 @@ namespace gr {
     }
 
     int waterfall_sink_f_proc_impl::get_buff_size(){
+      gr::thread::scoped_lock lock(d_setlock);
       return d_buffers.front()[0].size();
     }
 


### PR DESCRIPTION
To hopefully stop segfaults and neg size errors that occur randomly.

I guess there is some kind of race condition once in a while that causes corruption in the arrays returned by the fonctions to the python side of things.